### PR TITLE
Tf2.3  float64 precisions

### DIFF
--- a/configs/cascade_14param_noise_tw_Spice321.yaml
+++ b/configs/cascade_14param_noise_tw_Spice321.yaml
@@ -10,7 +10,7 @@
 unique_name: 'cascade_14param_noise_tw_Spice321'
 
 # the float precision to use
-float_precision: 'float64'
+float_precision: 'float32'
 
 #------------------
 # Training settings
@@ -108,7 +108,7 @@ reconstruction_settings: {
         'cascade_HoleIceForward_Unified_01': 0.,
         'cascade_Scattering': 1.,
     },
-    'seed_float_precision': 'float64',
+    'seed_float_precision': 'float32',
 
     # choose the otpimizer iterface:
     #   'scipy' or 'tfp' (tensorflow_probability)
@@ -317,7 +317,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float64',
+            'float_precision': 'float32',
             # Add normalization terms to llh if True
             'add_normalization_term': False,
             # choose the loss function to use
@@ -330,7 +330,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float64',
+            'float_precision': 'float32',
             # Add normalization terms to llh if True
             'add_normalization_term': False,
             # choose the loss function to use
@@ -376,7 +376,7 @@ evaluation_module_settings: {
 # Data Transformation settings
 #-----------------------------
 data_trafo_settings: {
-    'float_precision': 'float64',
+    'float_precision': 'float32',
     'norm_constant': !!float 1e-6,
     'num_batches': 5000,
     'model_dir': '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/trafo_models/trafo_model_snowstorm_mixed_cascade_no_fourier_pulse_data_noise_tw',
@@ -403,7 +403,7 @@ data_handler_settings: {
         'pulse_key': 'InIceDSTPulses_masked',
         'dom_exclusions_key': 'combined_exclusions_DOMs',
         'time_exclusions_key': 'combined_exclusions_TimeWindowsHDF5',
-        'float_precision': 'float64',
+        'float_precision': 'float32',
         'add_charge_quantiles': False,
         'discard_pulses_from_excluded_doms': False,
     },
@@ -424,7 +424,7 @@ data_handler_settings: {
         'additional_labels': ['energy_fraction_hadron'],
         'snowstorm_key': 'SnowstormParameters',
         'num_snowstorm_params': 6,
-        'float_precision': 'float64',
+        'float_precision': 'float32',
     },
 
     # ---------------------

--- a/configs/cascade_14param_noise_tw_Spice321.yaml
+++ b/configs/cascade_14param_noise_tw_Spice321.yaml
@@ -349,8 +349,8 @@ loss_module_settings: [
                 'cascade_AnisotropyScale': [0., 2.0],
                 'cascade_DOMEfficiency': [0.9, 1.1],
                 'cascade_Scattering': [0.9, 1.1],
-                'cascade_HoleIceForward_Unified_00': [-0.65, 0.60],
-                'cascade_HoleIceForward_Unified_01': [-0.08, 0.08],
+                'cascade_HoleIceForward_Unified_00': [-1.0, 1.0], #[-0.65, 0.60],
+                'cascade_HoleIceForward_Unified_01': [-0.2, 0.2], #[-0.08, 0.08],
             },
 
             # define fourier component sigmas
@@ -524,7 +524,7 @@ model_settings: {
 
                 # First convolutions
                 'filter_size_list' : [[1, 1], [1, 1], [1, 1], [1, 1], [1, 1], [1, 1]],
-                'num_filters_list' : [25, 500, 500, 500, 42],
+                'num_filters_list' : [25, 100, 100, 100, 42],
                 'method_list' : ['locally_connected',
                                  'convolution', 'convolution', 'convolution',
                                  'convolution',

--- a/configs/cascade_14param_noise_tw_Spice321.yaml
+++ b/configs/cascade_14param_noise_tw_Spice321.yaml
@@ -10,7 +10,7 @@
 unique_name: 'cascade_14param_noise_tw_Spice321'
 
 # the float precision to use
-float_precision: 'float32'
+float_precision: 'float64'
 
 #------------------
 # Training settings
@@ -108,7 +108,7 @@ reconstruction_settings: {
         'cascade_HoleIceForward_Unified_01': 0.,
         'cascade_Scattering': 1.,
     },
-    'seed_float_precision': 'float32',
+    'seed_float_precision': 'float64',
 
     # choose the otpimizer iterface:
     #   'scipy' or 'tfp' (tensorflow_probability)
@@ -317,7 +317,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': False,
             # choose the loss function to use
@@ -330,7 +330,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': False,
             # choose the loss function to use
@@ -376,7 +376,7 @@ evaluation_module_settings: {
 # Data Transformation settings
 #-----------------------------
 data_trafo_settings: {
-    'float_precision': 'float32',
+    'float_precision': 'float64',
     'norm_constant': !!float 1e-6,
     'num_batches': 5000,
     'model_dir': '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/trafo_models/trafo_model_snowstorm_mixed_cascade_no_fourier_pulse_data_noise_tw',
@@ -403,7 +403,7 @@ data_handler_settings: {
         'pulse_key': 'InIceDSTPulses_masked',
         'dom_exclusions_key': 'combined_exclusions_DOMs',
         'time_exclusions_key': 'combined_exclusions_TimeWindowsHDF5',
-        'float_precision': 'float32',
+        'float_precision': 'float64',
         'add_charge_quantiles': False,
         'discard_pulses_from_excluded_doms': False,
     },
@@ -424,7 +424,7 @@ data_handler_settings: {
         'additional_labels': ['energy_fraction_hadron'],
         'snowstorm_key': 'SnowstormParameters',
         'num_snowstorm_params': 6,
-        'float_precision': 'float32',
+        'float_precision': 'float64',
     },
 
     # ---------------------

--- a/egenerator/export_manager.py
+++ b/egenerator/export_manager.py
@@ -57,7 +57,7 @@ def main(config_files, output_dir, reco_config_file=None):
         reco_config_file = [reco_config_file]
 
     # limit GPU usage
-    gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+    gpu_devices = tf.config.list_physical_devices('GPU')
     for device in gpu_devices:
         tf.config.experimental.set_memory_growth(device, True)
 

--- a/egenerator/manager/base.py
+++ b/egenerator/manager/base.py
@@ -813,14 +813,12 @@ class BaseModelManager(Model):
 
                 # print out loss to console
                 msg = 'Step: {:08d}, Runtime: {:2.2f}s, Time/Step: {:3.3f}s'
-                self._logger.info(msg.format(
+                print(msg.format(
                     step, validation_time - start_time,
                     time_diff /
                     opt_config['validation_frequency']))
-                self._logger.info(
-                    '\t[Train]      {:3.3f}'.format(loss_training))
-                self._logger.info(
-                    '\t[Validation] {:3.3f}'.format(loss_validation))
+                print('\t[Train]      {:3.3f}'.format(loss_training))
+                print('\t[Validation] {:3.3f}'.format(loss_validation))
 
             # ------------------------------------------------
             # Perform additional evaluations on validation set

--- a/egenerator/model/source/cascade/charge_only.py
+++ b/egenerator/model/source/cascade/charge_only.py
@@ -294,6 +294,9 @@ class ChargeOnlyCascadeModel(Source):
         dom_charges_trafo = tf.expand_dims(conv_hex3d_layers[-1][..., 0],
                                            axis=-1)
 
+        # clip value range for more stability during training
+        dom_charges_trafo = tf.clip_by_value(dom_charges_trafo, -20., 15)
+
         # apply exponential which also forces positive values
         dom_charges = tf.exp(dom_charges_trafo)
 

--- a/egenerator/model/source/cascade/charge_quantiles.py
+++ b/egenerator/model/source/cascade/charge_quantiles.py
@@ -348,6 +348,9 @@ class ChargeQuantileCascadeModel(Source):
         dom_charges_trafo = tf.expand_dims(conv_hex3d_layers[-1][..., 0],
                                            axis=-1)
 
+        # clip value range for more stability during training
+        dom_charges_trafo = tf.clip_by_value(dom_charges_trafo, -20., 15)
+
         # apply exponential which also forces positive values
         dom_charges = tf.exp(dom_charges_trafo)
 

--- a/egenerator/model/source/cascade/default.py
+++ b/egenerator/model/source/cascade/default.py
@@ -523,6 +523,9 @@ class DefaultCascadeModel(Source):
         dom_charges_trafo = tf.expand_dims(conv_hex3d_layers[-1][..., 0],
                                            axis=-1)
 
+        # clip value range for more stability during training
+        dom_charges_trafo = tf.clip_by_value(dom_charges_trafo, -20., 15)
+
         # apply exponential which also forces positive values
         dom_charges = tf.exp(dom_charges_trafo)
 

--- a/egenerator/model/source/cascade/systematic.py
+++ b/egenerator/model/source/cascade/systematic.py
@@ -377,6 +377,9 @@ class SystematicsCascadeModel(Source):
         # the result of the convolution layers are the latent variables
         dom_charges_trafo = tf.expand_dims(conv_layers[-1][..., 0], axis=-1)
 
+        # clip value range for more stability during training
+        dom_charges_trafo = tf.clip_by_value(dom_charges_trafo, -20., 15)
+
         # apply exponential which also forces positive values
         dom_charges = tf.exp(dom_charges_trafo)
 

--- a/egenerator/model/source/track/stochastic_segment.py
+++ b/egenerator/model/source/track/stochastic_segment.py
@@ -529,6 +529,9 @@ class StochasticTrackSegmentModel(Source):
         dom_charges_trafo = tf.expand_dims(conv_hex3d_layers[-1][..., 0],
                                            axis=-1)
 
+        # clip value range for more stability during training
+        dom_charges_trafo = tf.clip_by_value(dom_charges_trafo, -20., 15)
+
         # apply exponential which also forces positive values
         dom_charges = tf.exp(dom_charges_trafo)
 

--- a/egenerator/reconstruct_test_data.py
+++ b/egenerator/reconstruct_test_data.py
@@ -42,7 +42,7 @@ def main(config_files, reco_config_file=None):
         reco_config_file = [reco_config_file]
 
     # limit GPU usage
-    gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+    gpu_devices = tf.config.list_physical_devices('GPU')
     for device in gpu_devices:
         tf.config.experimental.set_memory_growth(device, True)
 

--- a/egenerator/train_model.py
+++ b/egenerator/train_model.py
@@ -26,7 +26,7 @@ def main(config_files):
     """
 
     # limit GPU usage
-    gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+    gpu_devices = tf.config.list_physical_devices('GPU')
     for device in gpu_devices:
         tf.config.experimental.set_memory_growth(device, True)
 

--- a/egenerator/utils/configurator.py
+++ b/egenerator/utils/configurator.py
@@ -244,7 +244,7 @@ class ManagerConfigurator:
         tf.random.set_seed(tf_random_seed)
 
         # limit GPU usage
-        gpu_devices = tf.config.experimental.list_physical_devices('GPU')
+        gpu_devices = tf.config.list_physical_devices('GPU')
         for device in gpu_devices:
             tf.config.experimental.set_memory_growth(device, True)
 


### PR DESCRIPTION
Update to tensorflow 2.3 (higher versions should probably work as well) and support for float 64 precision. Added additional value clipping of dom_charges logits before exp operation to avoid too large numbers.