### PR TITLE
Feature/MCMC

### DIFF
--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -144,7 +144,7 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                           'frame key set via `seed_keys`, a default value may '
                           'be specified with the `missing_seed_value_dict` '
                           'dictionary. Entries have the format: '
-                          '{parameter_name}: default_value.',
+                          r'{parameter_name}: default_value.',
                           {})
         self.AddParameter('missing_seed_value',
                           'If a model parameter key is not given in the '

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -1,5 +1,6 @@
 import os
 import tensorflow as tf
+import numpy as np
 
 from icecube import dataclasses, icetray
 from icecube.icetray.i3logging import log_info, log_warn

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -560,12 +560,13 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                     # create some dummy values so that we fill in NaNs
                     values = np.ones(10) * float('nan')
 
-                result_dict['MCMC_{}_median'.format(n)] = np.median(values)
+                result_dict['MCMC_{}_median'.format(n)] = float(
+                    np.median(values))
                 for q in self.mcmc_quantiles:
-                    result_dict['MCMC_{}_q{:3.3f}_lower'.format(n, q)] = \
-                        np.quantile(values, 0.5 - 0.5*q)
-                    result_dict['MCMC_{}_q{:3.3f}_upper'.format(n, q)] = \
-                        np.quantile(values, 0.5 + 0.5*q)
+                    result_dict['MCMC_{}_q{:3.3f}_lower'.format(n, q)] = float(
+                        np.quantile(values, 0.5 - 0.5*q))
+                    result_dict['MCMC_{}_q{:3.3f}_upper'.format(n, q)] = float(
+                        np.quantile(values, 0.5 + 0.5*q))
 
             if num_accepted > 0:
                 # create vectors for output quantities

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -84,7 +84,7 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
         self.AddParameter('add_mcmc_samples',
                           'Add samples from a Markov-Chain-Monte-Carlo. '
                           'Settings for MCMC are defined in key '
-                          '`mcmc_settings`.'
+                          '`mcmc_settings`.',
                           False)
         self.AddParameter('label_key',
                           'Only relevant if labels are being loaded. '

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -525,7 +525,7 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                 vectors = {}
                 for i, n in enumerate(self.manager.models[0].parameter_names):
                     vectors[n] = dataclasses.I3VectorFloat(
-                        mcmc_res['samples'][i])
+                        mcmc_res['samples'][:, i])
                 vectors['log_prob_values'] = dataclasses.I3VectorFloat(
                     mcmc_res['log_prob_values'])
 

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -562,9 +562,9 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
 
                 result_dict['MCMC_{}_median'.format(n)] = np.median(values)
                 for q in self.mcmc_quantiles:
-                    result_dict['MCMC_{}_q{:3.3f}_lower'.format(n)] = \
+                    result_dict['MCMC_{}_q{:3.3f}_lower'.format(n, q)] = \
                         np.quantile(values, 0.5 - 0.5*q)
-                    result_dict['MCMC_{}_q{:3.3f}_upper'.format(n)] = \
+                    result_dict['MCMC_{}_q{:3.3f}_upper'.format(n, q)] = \
                         np.quantile(values, 0.5 + 0.5*q)
 
             if num_accepted > 0:

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -144,7 +144,7 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                           'frame key set via `seed_keys`, a default value may '
                           'be specified with the `missing_seed_value_dict` '
                           'dictionary. Entries have the format: '
-                          '{parameter_name}: default_value.'
+                          '{parameter_name}: default_value.',
                           {})
         self.AddParameter('missing_seed_value',
                           'If a model parameter key is not given in the '

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -139,6 +139,22 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                           'parameters will default to '
                           '`minimize_parameter_default_value`.',
                           True)
+        self.AddParameter('missing_seed_value_dict',
+                          'If a certain model parameter does not exist in the '
+                          'frame key set via `seed_keys`, a default value may '
+                          'be specified with the `missing_seed_value_dict` '
+                          'dictionary. Entries have the format: '
+                          '{parameter_name}: default_value.'
+                          {})
+        self.AddParameter('missing_seed_value',
+                          'If a model parameter key is not given in the '
+                          'provided seed_key, it can be replaced with a '
+                          'default value defined in `missing_seed_value`. '
+                          'Note that this value will be set for any and all '
+                          'parameters that are not found. Keep in mind that '
+                          'this will also work if the wrong frame key is '
+                          'provided by accident to `seed_keys`.',
+                          None)
         self.AddParameter('reco_optimizer_interface',
                           'The reconstruction interface to use. Options are: '
                           '"scipy" or "tfp" (tensorflow_probability).',
@@ -214,8 +230,9 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
             self.GetParameter('goodness_of_fit_settings')
         self.mcmc_settings = self.GetParameter('mcmc_settings')
 
-        self.missing_value_dict = {}
-        self.missing_value = None
+        self.missing_seed_value_dict = \
+            self.GetParameter('missing_seed_value_dict')
+        self.missing_seed_value = self.GetParameter('missing_seed_value')
 
         if 'reconstruct_samples' not in self.goodness_of_fit_settings:
             self.goodness_of_fit_settings['reconstruct_samples'] = True
@@ -257,8 +274,8 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
             additional_loss_modules=additional_loss_modules,
             misc_setting_updates={
                 'seed_names': self.seed_keys,
-                'missing_value_dict': self.missing_value_dict,
-                'missing_value': self.missing_value,
+                'missing_value_dict': self.missing_seed_value_dict,
+                'missing_value': self.missing_seed_value,
             },
             label_setting_updates={
                 'label_key': self.label_key,

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -302,7 +302,7 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                               for i in
                               range(self.manager.models[0].num_parameters)]
         for name, value in self.minimize_parameter_dict.items():
-            fit_parameter_list[self.manager.models[0].get_index(name)] =
+            fit_parameter_list[self.manager.models[0].get_index(name)] = value
         self.fit_parameter_list = fit_parameter_list
 
         # parameter input signature

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -558,7 +558,7 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                     values = mcmc_res['samples'][:, i]
                 else:
                     # create some dummy values so that we fill in NaNs
-                    values = np.ones(12) * float('nan')
+                    values = np.ones(10) * float('nan')
 
                 result_dict['MCMC_{}_median'.format(n)] = np.median(values)
                 for q in self.mcmc_quantiles:

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -529,8 +529,8 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                 vectors['log_prob_values'] = dataclasses.I3VectorFloat(
                     mcmc_res['log_prob_values'])
 
-            for n, vector in vectors.items():
-                frame[self.output_key + '_MCMC_' + n] = vector
+                for n, vector in vectors.items():
+                    frame[self.output_key + '_MCMC_' + n] = vector
 
         # save to frame
         frame[self.output_key] = result_dict

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -195,6 +195,11 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                             'mcmc_num_steps_between_results': 0,
                             'mcmc_num_parallel_iterations': 1,
                           })
+        self.AddParameter('mcmc_quantiles',
+                          'Only relevant if `add_mcmc_samples` is set '
+                          ' to "True". Defines quantiles of MCMC samples to '
+                          'add to result frame key of reconstruction.',
+                          [0.5, 0.68, 0.9])
 
     def Configure(self):
         """Configures Module and loads model from file.
@@ -230,7 +235,7 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
         self.goodness_of_fit_settings = \
             self.GetParameter('goodness_of_fit_settings')
         self.mcmc_settings = self.GetParameter('mcmc_settings')
-        self.mcmc_quantiles = [0.5, 0.68, 0.9]
+        self.mcmc_quantiles = self.GetParameter('mcmc_quantiles')
 
         self.missing_seed_value_dict = \
             self.GetParameter('missing_seed_value_dict')

--- a/egenerator/ic3/reconstruction.py
+++ b/egenerator/ic3/reconstruction.py
@@ -214,6 +214,9 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
             self.GetParameter('goodness_of_fit_settings')
         self.mcmc_settings = self.GetParameter('mcmc_settings')
 
+        self.missing_value_dict = {}
+        self.missing_value = None
+
         if 'reconstruct_samples' not in self.goodness_of_fit_settings:
             self.goodness_of_fit_settings['reconstruct_samples'] = True
         if 'add_per_dom_calculation' not in self.goodness_of_fit_settings:
@@ -254,6 +257,8 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
             additional_loss_modules=additional_loss_modules,
             misc_setting_updates={
                 'seed_names': self.seed_keys,
+                'missing_value_dict': self.missing_value_dict,
+                'missing_value': self.missing_value,
             },
             label_setting_updates={
                 'label_key': self.label_key,
@@ -297,7 +302,8 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                               for i in
                               range(self.manager.models[0].num_parameters)]
         for name, value in self.minimize_parameter_dict.items():
-            fit_parameter_list[self.manager.models[0].get_index(name)] = value
+            fit_parameter_list[self.manager.models[0].get_index(name)] =
+        self.fit_parameter_list = fit_parameter_list
 
         # parameter input signature
         parameter_tensor_name = 'x_parameters'
@@ -524,8 +530,9 @@ class EventGeneratorReconstruction(icetray.I3ConditionalModule):
                 # create vectors for output quantities
                 vectors = {}
                 for i, n in enumerate(self.manager.models[0].parameter_names):
-                    vectors[n] = dataclasses.I3VectorFloat(
-                        mcmc_res['samples'][:, i])
+                    if self.fit_parameter_list[i]:
+                        vectors[n] = dataclasses.I3VectorFloat(
+                            mcmc_res['samples'][:, i])
                 vectors['log_prob_values'] = dataclasses.I3VectorFloat(
                     mcmc_res['log_prob_values'])
 

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -84,6 +84,9 @@ class MarkovChainMonteCarlo:
         param_signature = tf.TensorSpec(
             shape=[None, np.sum(fit_parameter_list, dtype=int)],
             dtype=self.param_dtype)
+        param_signature_full = tf.TensorSpec(
+            shape=[None, len(fit_parameter_list)],
+            dtype=param_dtype)
 
         data_batch_signature = manager.data_handler.get_data_set_signature()
 
@@ -145,9 +148,6 @@ class MarkovChainMonteCarlo:
         TYPE
             Description
         """
-
-        num_params = len(self.fit_parameter_list)
-
         # get seed: either from seed tensor or from previous results
         if 'result' in results[self.reco_key]:
             # this is a previous reconstruction result

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -174,7 +174,7 @@ class MarkovChainMonteCarlo:
             initial_position = initial_position
         else:
             # get seed parameters
-            initial_position = initial_position[..., fit_parameter_list]
+            initial_position = initial_position[..., self.fit_parameter_list]
         print('initial_position.shape [fit_parameter_list]', initial_position.shape)
 
         mcmc_start_t = timeit.default_timer()

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -208,6 +208,9 @@ class MarkovChainMonteCarlo:
         print('samples post sel:', samples.shape)
         print('log_prob_values post sel:', log_prob_values.shape)
 
+        print('debug samples', samples.shape)
+        print('debug result_inv', result_inv.shape)
+        print('debug fit_parameter_list', self.fit_parameter_list)
         # invert possible transformation and put full hypothesis together
         samples = trafo.get_reco_result_batch(
             result_trafo=samples,

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -112,7 +112,6 @@ class MarkovChainMonteCarlo:
                 fit_parameter_list=fit_parameter_list,
                 minimize_in_trafo_space=minimize_in_trafo_space,
                 num_chains=mcmc_num_chains,
-                seed=seed_tensor_name,
                 method=mcmc_method,
                 num_results=mcmc_num_results,
                 num_burnin_steps=mcmc_num_burnin_steps,

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -214,7 +214,7 @@ class MarkovChainMonteCarlo:
         # invert possible transformation and put full hypothesis together
         samples = trafo.get_reco_result_batch(
             result_trafo=samples,
-            seed_tensor=result_inv,
+            seed_tensor=np.tile(result_inv[0], [len(samples), 1]),
             fit_parameter_list=self.fit_parameter_list,
             minimize_in_trafo_space=self.minimize_in_trafo_space,
             data_trafo=self.manager.data_trafo,

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -195,7 +195,8 @@ class MarkovChainMonteCarlo:
             step_size = steps[0][0]
             if self.minimize_in_trafo_space:
                 step_size *= self.manager.data_trafo.data[
-                                        self.parameter_tensor_name+'_std']
+                    self.parameter_tensor_name+'_std'][
+                        self.fit_parameter_list]
 
         num_accepted = np.sum(accepted)
         num_samples = samples.shape[0] * samples.shape[1]

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -227,7 +227,9 @@ class MarkovChainMonteCarlo:
                 mcmc_end_t - mcmc_start_t))
             print('\tAcceptance Ratio: {:2.1f}%'.format(
                 (100. * num_accepted) / num_samples))
-            msg = '{:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f}'
+            msg = ''
+            for s in step_size:
+                msg += '{:1.4f} '
             if len(trace) > 2:
                 print('\tStepsize [sampled space]: ' + msg.format(
                     *step_size_trafo))

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -86,7 +86,7 @@ class MarkovChainMonteCarlo:
             dtype=self.param_dtype)
         param_signature_full = tf.TensorSpec(
             shape=[None, len(fit_parameter_list)],
-            dtype=param_dtype)
+            dtype=self.param_dtype)
 
         data_batch_signature = manager.data_handler.get_data_set_signature()
 

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -161,14 +161,11 @@ class MarkovChainMonteCarlo:
         initial_position = np.reshape(
             np.tile(result_inv[0], [self.mcmc_num_chains, 1]),
             [self.mcmc_num_chains, len(self.fit_parameter_list)])
-        print('initial_position', initial_position)
-        print('initial_position.shape', initial_position.shape)
 
         if self.minimize_in_trafo_space:
             initial_position = self.manager.data_trafo.transform(
                                     data=initial_position,
                                     tensor_name=self.parameter_tensor_name)
-            print('initial_position [norm]', initial_position)
 
         # get seed parameters
         if np.all(self.fit_parameter_list):
@@ -176,8 +173,6 @@ class MarkovChainMonteCarlo:
         else:
             # get seed parameters
             initial_position = initial_position[..., self.fit_parameter_list]
-
-        print('initial_position.shape [fit_parameter_list]', initial_position.shape)
 
         initial_position = tf.convert_to_tensor(
             initial_position, dtype=self.param_dtype)
@@ -202,17 +197,11 @@ class MarkovChainMonteCarlo:
 
         num_accepted = np.sum(accepted)
         num_samples = samples.shape[0] * samples.shape[1]
+        acceptance_ratio = float(num_accepted) / num_samples
 
-        print('samples pre sel:', samples.shape)
-        print('log_prob_values pre sel:', log_prob_values.shape)
         samples = samples[accepted]
         log_prob_values = log_prob_values[accepted]
-        print('samples post sel:', samples.shape)
-        print('log_prob_values post sel:', log_prob_values.shape)
 
-        print('debug samples', samples.shape)
-        print('debug result_inv', result_inv.shape)
-        print('debug fit_parameter_list', self.fit_parameter_list)
         # invert possible transformation and put full hypothesis together
         samples = trafo.get_reco_result_batch(
             result_trafo=samples,
@@ -225,8 +214,7 @@ class MarkovChainMonteCarlo:
         if self.verbose:
             print('MCMC Results took {:3.3f}s:'.format(
                 mcmc_end_t - mcmc_start_t))
-            print('\tAcceptance Ratio: {:2.1f}%'.format(
-                (100. * num_accepted) / num_samples))
+            print('\tAcceptance Ratio: {:2.1f}%'.format(100.*acceptance_ratio))
             msg = ''
             for s in step_size:
                 msg += '{:1.4f} '
@@ -239,6 +227,7 @@ class MarkovChainMonteCarlo:
         results = {
             'samples': samples,
             'log_prob_values': log_prob_values,
+            'acceptance_ratio': acceptance_ratio,
         }
 
         return results

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -2,6 +2,8 @@ import timeit
 import numpy as np
 import tensorflow as tf
 
+from egenerator.manager.reconstruction.modules.utils import trafo
+
 
 class MarkovChainMonteCarlo:
 

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -155,10 +155,8 @@ class MarkovChainMonteCarlo:
 
         assert len(result_inv) == 1
 
-        initial_position = tf.reshape(
-            tf.convert_to_tensor(
-                np.tile(result_inv[0], [self.mcmc_num_chains, 1]),
-                dtype=self.param_dtype),
+        initial_position = np.reshape(
+            np.tile(result_inv[0], [self.mcmc_num_chains, 1]),
             [self.mcmc_num_chains, len(self.fit_parameter_list)])
         print('initial_position', initial_position)
         print('initial_position.shape', initial_position.shape)
@@ -175,7 +173,11 @@ class MarkovChainMonteCarlo:
         else:
             # get seed parameters
             initial_position = initial_position[..., self.fit_parameter_list]
+
         print('initial_position.shape [fit_parameter_list]', initial_position.shape)
+
+        initial_position = tf.convert_to_tensor(
+            initial_position, dtype=self.param_dtype)
 
         mcmc_start_t = timeit.default_timer()
         samples, trace = self.run_mcmc_on_events(initial_position, data_batch)

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -148,7 +148,7 @@ class MarkovChainMonteCarlo:
         # get seed: either from seed tensor or from previous results
         if 'result' in results[self.reco_key]:
             # this is a previous reconstruction result
-            result_inv = results[self.reco_key]['results']
+            result_inv = results[self.reco_key]['result']
         else:
             # this could be a seed tensor
             result_inv = results[self.reco_key]
@@ -212,7 +212,6 @@ class MarkovChainMonteCarlo:
         msg = '{:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f}'
         if len(trace) > 2:
             print('\tStepsize: ' + msg.format(*step_size))
-        msg = '{:1.2f} {:1.2f} {:1.2f} {:1.2f} {:1.2f} {:1.2f} {:1.2f}'
 
         # gather results
         results = {

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -192,11 +192,13 @@ class MarkovChainMonteCarlo:
         log_prob_values = trace[1].numpy()
         if len(trace) > 2:
             steps = trace[2].numpy()
-            step_size = steps[0][0]
+            step_size_trafo = steps[0][0]
             if self.minimize_in_trafo_space:
-                step_size *= self.manager.data_trafo.data[
+                step_size = step_size_trafo * self.manager.data_trafo.data[
                     self.parameter_tensor_name+'_std'][
                         self.fit_parameter_list]
+            else:
+                step_size = step_size_trafo
 
         num_accepted = np.sum(accepted)
         num_samples = samples.shape[0] * samples.shape[1]
@@ -227,7 +229,9 @@ class MarkovChainMonteCarlo:
                 (100. * num_accepted) / num_samples))
             msg = '{:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f} {:1.4f}'
             if len(trace) > 2:
-                print('\tStepsize: ' + msg.format(*step_size))
+                print('\tStepsize [sampled space]: ' + msg.format(
+                    *step_size_trafo))
+                print('\tStepsize [true space]: ' + msg.format(*step_size))
 
         # gather results
         results = {

--- a/egenerator/manager/reconstruction/modules/reconstruction.py
+++ b/egenerator/manager/reconstruction/modules/reconstruction.py
@@ -295,7 +295,9 @@ class Reconstruction:
 
 class SelectBestReconstruction:
 
-    def __init__(self, manager, loss_module, function_cache, reco_names):
+    def __init__(
+            self, manager, loss_module, function_cache, reco_names,
+            verbose=True):
         """Initialize reconstruction module and setup tensorflow functions.
 
         Parameters
@@ -310,15 +312,13 @@ class SelectBestReconstruction:
             A list of reco names from previous reconstruction modules. The
             best reconstruction, e.g. lowest reco loss, will be chosen from
             these reconstructions.
-
-        Raises
-        ------
-        ValueError
-            Description
+        verbose : bool, optional
+            If True, additional information will be printed to the console.
         """
 
         # store settings
         self.reco_names = reco_names
+        self.verbose = verbose
 
     def execute(self, data_batch, results, **kwargs):
         """Execute selection.

--- a/egenerator/manager/reconstruction/modules/reconstruction.py
+++ b/egenerator/manager/reconstruction/modules/reconstruction.py
@@ -268,8 +268,6 @@ class Reconstruction:
         result_trafo, result_object = self.reconstruction_method(
             data_batch, seed_tensor)
 
-        print('reco: seed_tensor', seed_tensor)
-        print('reco: result_trafo', result_trafo)
         # invert possible transformation and put full hypothesis together
         result = trafo.get_reco_result_batch(
             result_trafo=result_trafo,
@@ -278,7 +276,6 @@ class Reconstruction:
             minimize_in_trafo_space=self.minimize_in_trafo_space,
             data_trafo=self.manager.data_trafo,
             parameter_tensor_name=self.parameter_tensor_name)
-        print('reco: result', result)
 
         loss_seed = self.parameter_loss_function(
             seed_tensor, data_batch).numpy()

--- a/egenerator/manager/reconstruction/modules/reconstruction.py
+++ b/egenerator/manager/reconstruction/modules/reconstruction.py
@@ -17,6 +17,7 @@ class Reconstruction:
                  scipy_optimizer_settings={'method': 'BFGS'},
                  tf_optimizer_settings={'method': 'bfgs_minimize',
                                         'x_tolerance': 0.001},
+                 verbose=True,
                  ):
         """Initialize reconstruction module and setup tensorflow functions.
 
@@ -54,6 +55,8 @@ class Reconstruction:
             parameter space. This is usually desired, because the scales of
             the parameters will all be normalized which should facilitate
             minimization.
+        randomize_seed : bool, optional
+            Description
         parameter_tensor_name : str, optional
             The name of the parameter tensor to use. Default: 'x_parameters'.
         reco_optimizer_interface : str, optional
@@ -65,6 +68,8 @@ class Reconstruction:
         tf_optimizer_settings : dict, optional
             Settings that will be passed on to the tensorflow probability
             minimizer.
+        verbose : bool, optional
+            If True, additional information will be printed to the console.
 
         Raises
         ------
@@ -80,6 +85,7 @@ class Reconstruction:
         self.seed_tensor_name = seed_tensor_name
         self.seed_from_previous_module = seed_from_previous_module
         self.randomize_seed = randomize_seed
+        self.verbose = verbose
 
         if not self.seed_from_previous_module:
             self.seed_index = manager.data_handler.tensors.get_index(
@@ -253,7 +259,8 @@ class Reconstruction:
             # # set vertex to MC truth
             # x0[:, :3] = x_true[:, :3]
             # x0[:, 6] = x_true[:, 6]
-            print('New Seed:', x0)
+            if self.verbose:
+                print('New Seed:', x0)
 
             seed_tensor = x0
         # -------------------
@@ -338,8 +345,9 @@ class SelectBestReconstruction:
         for reco_name in self.reco_names:
             reco_results = results[reco_name]
 
-            print('Loss: {:3.3f} | {}'.format(
-                reco_results['loss_reco'], reco_name))
+            if self.verbose:
+                print('Loss: {:3.3f} | {}'.format(
+                    reco_results['loss_reco'], reco_name))
 
             # check if it has a lower loss
             if reco_results['loss_reco'] < min_loss:

--- a/egenerator/manager/reconstruction/modules/reconstruction.py
+++ b/egenerator/manager/reconstruction/modules/reconstruction.py
@@ -268,6 +268,8 @@ class Reconstruction:
         result_trafo, result_object = self.reconstruction_method(
             data_batch, seed_tensor)
 
+        print('reco: seed_tensor', seed_tensor)
+        print('reco: result_trafo', result_trafo)
         # invert possible transformation and put full hypothesis together
         result = trafo.get_reco_result_batch(
             result_trafo=result_trafo,
@@ -276,6 +278,7 @@ class Reconstruction:
             minimize_in_trafo_space=self.minimize_in_trafo_space,
             data_trafo=self.manager.data_trafo,
             parameter_tensor_name=self.parameter_tensor_name)
+        print('reco: result', result)
 
         loss_seed = self.parameter_loss_function(
             seed_tensor, data_batch).numpy()

--- a/egenerator/manager/reconstruction/modules/utils/trafo.py
+++ b/egenerator/manager/reconstruction/modules/utils/trafo.py
@@ -62,7 +62,9 @@ def get_reco_result_batch(result_trafo,
                 result_counter += 1
             else:
                 cascade_reco_batch.append(cascade_seed_batch_trafo[:, i])
+        print('cascade_reco_batch', cascade_reco_batch.shape)
         cascade_reco_batch = np.array(cascade_reco_batch).T
+        print('cascade_reco_batch nump', cascade_reco_batch.shape)
 
     # transform back if minimization was performed in trafo space
     if minimize_in_trafo_space:

--- a/egenerator/manager/reconstruction/modules/utils/trafo.py
+++ b/egenerator/manager/reconstruction/modules/utils/trafo.py
@@ -62,7 +62,7 @@ def get_reco_result_batch(result_trafo,
                 result_counter += 1
             else:
                 cascade_reco_batch.append(cascade_seed_batch_trafo[:, i])
-        print('cascade_reco_batch', cascade_reco_batch.shape)
+        print('cascade_reco_batch', cascade_reco_batch)
         cascade_reco_batch = np.array(cascade_reco_batch).T
         print('cascade_reco_batch nump', cascade_reco_batch.shape)
 

--- a/egenerator/manager/reconstruction/modules/utils/trafo.py
+++ b/egenerator/manager/reconstruction/modules/utils/trafo.py
@@ -62,9 +62,7 @@ def get_reco_result_batch(result_trafo,
                 result_counter += 1
             else:
                 cascade_reco_batch.append(cascade_seed_batch_trafo[:, i])
-        print('cascade_reco_batch', cascade_reco_batch)
         cascade_reco_batch = np.array(cascade_reco_batch).T
-        print('cascade_reco_batch nump', cascade_reco_batch.shape)
 
     # transform back if minimization was performed in trafo space
     if minimize_in_trafo_space:

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -1348,7 +1348,7 @@ class SourceManager(BaseModelManager):
 
             if num_params != len(step_size):
                 step_size = [[
-                    s for (s, f) in zip(step_size, fit_parameter_list) if f
+                    s for (s, f) in zip(step_size[0], fit_parameter_list) if f
                 ]]
 
         step_size = np.array(step_size)

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -1309,8 +1309,8 @@ class SourceManager(BaseModelManager):
             Description
         """
 
-        num_params = initial_position.shape[1]
-        assert np.sum(fit_parameter_list) == num_params
+        num_params = np.sum(fit_parameter_list)
+        assert initial_position.shape[1] == num_params
         initial_position = tf.ensure_shape(initial_position,
                                            [num_chains, num_params])
 
@@ -1346,7 +1346,7 @@ class SourceManager(BaseModelManager):
         parameter_dtype = getattr(tf, param_tensor.dtype)
 
         step_size = tf.convert_to_tensor(step_size, dtype=parameter_dtype)
-        step_size = tf.reshape(step_size, [1, len(fit_parameter_list)])
+        step_size = tf.reshape(step_size, [1, num_params])
 
         # Define transition kernel
         if method == 'HamiltonianMonteCarlo':

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -1339,17 +1339,17 @@ class SourceManager(BaseModelManager):
 
         # Define step sizes
         if minimize_in_trafo_space:
-            step_size = [[0.1 for p in range(num_params)]]
+            step_size = [[0.01 for p in range(num_params)]]
         else:
             # step sizes for x, y, z, zenith, azimuth, energy, time
             step_size = [[.5, .5, .5, 0.02, 0.02, 10., 1.]]
             if method == 'HamiltonianMonteCarlo':
                 step_size = [[.1, .1, .1, 0.01, 0.02, 10., 1.]]
 
-            if num_params != len(step_size):
-                step_size = [[
-                    s for (s, f) in zip(step_size[0], fit_parameter_list) if f
-                ]]
+        if num_params != len(step_size):
+            step_size = [[
+                s for (s, f) in zip(step_size[0], fit_parameter_list) if f
+            ]]
 
         step_size = np.array(step_size)
 

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -1400,15 +1400,6 @@ class SourceManager(BaseModelManager):
                 kernel=adaptive_hmc,
                 trace_fn=trace_fn,
                 parallel_iterations=num_parallel_iterations)
-            # samples = tf.reshape(samples,
-            #                      [num_chains*num_results, num_params])
-            # if minimize_in_trafo_space:
-            #     samples = self.data_trafo.inverse_transform(
-            #         data=samples, tensor_name=parameter_tensor_name)
-
-            # samples = tf.reshape(samples,
-            #                      [num_results, num_chains, num_params])
-            print('runchaing samples.shape', samples.shape)
 
             return samples, trace
         return run_chain()

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -1226,7 +1226,6 @@ class SourceManager(BaseModelManager):
                            fit_parameter_list,
                            minimize_in_trafo_space=True,
                            num_chains=1,
-                           seed=None,
                            num_results=100,
                            num_burnin_steps=100,
                            num_parallel_iterations=1,
@@ -1262,8 +1261,6 @@ class SourceManager(BaseModelManager):
             minimization.
         num_chains : int, optional
             Number of chains to run
-        seed : str, optional
-            Name of seed tensor
         num_results : int, optional
             The number of chain steps to perform after burnin phase.
         num_burnin_steps : int, optional

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -1314,7 +1314,7 @@ class SourceManager(BaseModelManager):
 
         """
 
-        num_params = np.sum(fit_parameter_list)
+        num_params = np.sum(fit_parameter_list, dtype=int)
         assert initial_position.shape[1] == num_params
         initial_position = tf.ensure_shape(initial_position,
                                            [num_chains, num_params])


### PR DESCRIPTION
Adds functionality to perform MCMC sampling via provided I3Module. Also fixes some issues in the previous MCMC implementation in which the sampling was not properly performed in the transformed space.
Changes default behaviour of loaded `seed_keys`. If model parameter names are not given in the provided I3Frame key, these are now not replaced by default. An option is added to the I3Module to set replacement values.