### PR TITLE
Fix numpy deprectation warning for builtin dtypes

### DIFF
--- a/egenerator/data/handler/base.py
+++ b/egenerator/data/handler/base.py
@@ -336,7 +336,7 @@ class BaseDataHandler(BaseComponent):
             if tensor.exists:
                 data_tensors.append(data[i])
             else:
-                data_tensors.append(getattr(np, tensor.dtype)())
+                data_tensors.append(tensor.dtype_np())
 
         return num_events, tuple(data_tensors)
 
@@ -383,7 +383,7 @@ class BaseDataHandler(BaseComponent):
             if tensor.exists:
                 data_tensors.append(tf.convert_to_tensor(data[i]))
             else:
-                data_tensors.append(getattr(np, tensor.dtype)())
+                data_tensors.append(tensor.dtype_np())
         return tuple(data_tensors)
 
     def _get_data_from_frame(self, frame, *args, **kwargs):
@@ -929,7 +929,7 @@ class BaseDataHandler(BaseComponent):
                                     indices[:, 0] = size
                                     batch[i].append(indices)
                             else:
-                                batch[i].append(getattr(np, tensor.dtype)())
+                                batch[i].append(tensor.dtype_np())
                                 # batch[i].append(None)
                         size += 1
 
@@ -941,17 +941,17 @@ class BaseDataHandler(BaseComponent):
                                 if exists[i]:
                                     if tensor.vector_info is None:
                                         batch[i] = np.asarray(
-                                            batch[i],
-                                            dtype=getattr(np, tensor.dtype))
+                                            batch[i], dtype=tensor.dtype_np,
+                                        )
 
                                     else:
                                         batch[i] = np.concatenate(
                                                 batch[i], axis=0).astype(
-                                                    getattr(np, tensor.dtype))
+                                                    tensor.dtype_np)
                                 else:
                                     batch[i] = np.asarray(
-                                            batch[i],
-                                            dtype=getattr(np, tensor.dtype))
+                                            batch[i], dtype=tensor.dtype_np,
+                                    )
 
                             if verbose:
                                 usage = resource.getrusage(
@@ -1114,7 +1114,7 @@ class BaseDataHandler(BaseComponent):
         output_types = []
         output_shapes = []
         for tensor in self.tensors.list:
-            output_types.append(getattr(tf, tensor.dtype))
+            output_types.append(tensor.dtype_tf)
             if tensor.exists:
                 output_shapes.append(tf.TensorShape(tensor.shape))
             else:
@@ -1144,7 +1144,7 @@ class BaseDataHandler(BaseComponent):
             else:
                 shape = tf.TensorShape(None)
             spec.append(
-                tf.TensorSpec(shape=shape, dtype=getattr(tf, tensor.dtype)))
+                tf.TensorSpec(shape=shape, dtype=tensor.dtype_tf))
         return tuple(spec)
 
     def kill(self):

--- a/egenerator/data/tensor.py
+++ b/egenerator/data/tensor.py
@@ -1,5 +1,6 @@
 from __future__ import division, print_function
 import numpy as np
+import tensorflow as tf
 from copy import deepcopy
 
 

--- a/egenerator/manager/reconstruction/modules/covariance.py
+++ b/egenerator/manager/reconstruction/modules/covariance.py
@@ -49,8 +49,8 @@ class CovarianceMatrix:
         self.minimize_in_trafo_space = minimize_in_trafo_space
         self.parameter_tensor_name = parameter_tensor_name
 
-        param_dtype = getattr(tf, manager.data_trafo.data['tensors'][
-            parameter_tensor_name].dtype)
+        param_dtype = manager.data_trafo.data['tensors'][
+            parameter_tensor_name].dtype_tf
         param_signature = tf.TensorSpec(
             shape=[None, np.sum(fit_parameter_list, dtype=int)],
             dtype=param_dtype)

--- a/egenerator/manager/reconstruction/modules/fit_quality.py
+++ b/egenerator/manager/reconstruction/modules/fit_quality.py
@@ -119,8 +119,8 @@ class GoodnessOfFit:
         self.param_time_index = self.manager.models[0].get_index('time')
 
         # parameter input signature
-        self.param_dtype = getattr(tf, self.manager.data_trafo.data['tensors'][
-            parameter_tensor_name].dtype)
+        self.param_dtype = self.manager.data_trafo.data['tensors'][
+            parameter_tensor_name].dtype_tf
         param_signature = tf.TensorSpec(
             shape=[None, np.sum(fit_parameter_list, dtype=int)],
             dtype=self.param_dtype)

--- a/egenerator/manager/reconstruction/modules/mcmc.py
+++ b/egenerator/manager/reconstruction/modules/mcmc.py
@@ -103,8 +103,8 @@ class MarkovChainMonteCarlo:
         self.rng = np.random.RandomState(random_seed)
 
         # parameter input signature
-        self.param_dtype = getattr(tf, manager.data_trafo.data['tensors'][
-            parameter_tensor_name].dtype)
+        self.param_dtype = manager.data_trafo.data['tensors'][
+            parameter_tensor_name].dtype_tf
         param_signature = tf.TensorSpec(
             shape=[None, np.sum(fit_parameter_list, dtype=int)],
             dtype=self.param_dtype)

--- a/egenerator/manager/reconstruction/modules/opening_angle.py
+++ b/egenerator/manager/reconstruction/modules/opening_angle.py
@@ -87,8 +87,8 @@ class CircularizedAngularUncertainty:
         self.unc_fit_parameter_list[self.azimuth_index] = False
 
         # parameter input signature
-        self.param_dtype = getattr(tf, manager.data_trafo.data['tensors'][
-            parameter_tensor_name].dtype)
+        self.param_dtype = manager.data_trafo.data['tensors'][
+            parameter_tensor_name].dtype_tf
 
         unc_param_signature = tf.TensorSpec(
             shape=[None, np.sum(self.unc_fit_parameter_list, dtype=int)],

--- a/egenerator/manager/reconstruction/modules/reconstruction.py
+++ b/egenerator/manager/reconstruction/modules/reconstruction.py
@@ -96,8 +96,8 @@ class Reconstruction:
                 seed_tensor_name)
 
         # parameter input signature
-        param_dtype = getattr(tf, manager.data_trafo.data['tensors'][
-            parameter_tensor_name].dtype)
+        param_dtype = manager.data_trafo.data['tensors'][
+            parameter_tensor_name].dtype_tf
         param_signature = tf.TensorSpec(
             shape=[None, np.sum(fit_parameter_list, dtype=int)],
             dtype=param_dtype)

--- a/egenerator/manager/reconstruction/modules/visualization.py
+++ b/egenerator/manager/reconstruction/modules/visualization.py
@@ -52,8 +52,8 @@ class Visualize1DLikelihoodScan:
         self.param_index = manager.data_handler.tensors.get_index(
             parameter_tensor_name)
 
-        param_dtype = getattr(tf, manager.data_trafo.data['tensors'][
-            parameter_tensor_name].dtype)
+        param_dtype = manager.data_trafo.data['tensors'][
+            parameter_tensor_name].dtype_tf
         param_signature = tf.TensorSpec(
             shape=[None, np.sum(fit_parameter_list, dtype=int)],
             dtype=param_dtype)

--- a/egenerator/manager/reconstruction/modules/visualize_pulses.py
+++ b/egenerator/manager/reconstruction/modules/visualize_pulses.py
@@ -69,7 +69,7 @@ class VisualizePulseLikelihood:
 
         param_tensor = manager.data_trafo.data['tensors'][
             parameter_tensor_name]
-        param_dtype = getattr(tf, param_tensor.dtype)
+        param_dtype = param_tensor.dtype_tf
         param_signature = tf.TensorSpec(
             shape=param_tensor.shape,
             dtype=param_dtype)

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -573,16 +573,13 @@ class SourceManager(BaseModelManager):
         """
         model = self.models[model_index]
 
-        pulse_dtype = getattr(
-            tf, self.data_trafo.data['tensors']['x_pulses'].dtype)
-        id_dtype = getattr(
-            tf, self.data_trafo.data['tensors']['x_pulses_ids'].dtype)
-        param_dtype = getattr(
-            tf, self.data_trafo.data['tensors']['x_parameters'].dtype)
-        tw_dtype = getattr(
-            tf, self.data_trafo.data['tensors']['x_time_window'].dtype)
-        t_exclusions_dtype = getattr(
-            tf, self.data_trafo.data['tensors']['x_time_exclusions'].dtype)
+        pulse_dtype = self.data_trafo.data['tensors']['x_pulses'].dtype_tf
+        id_dtype = self.data_trafo.data['tensors']['x_pulses_ids'].dtype_tf
+        param_dtype = self.data_trafo.data['tensors']['x_parameters'].dtype_tf
+        tw_dtype = self.data_trafo.data['tensors']['x_time_window'].dtype_tf
+        t_exclusions_dtype = self.data_trafo.data['tensors'][
+            'x_time_exclusions'].dtype_tf
+
         param_signature = tf.TensorSpec(
             shape=[None, model.num_parameters], dtype=param_dtype)
         x_pulses_shape = self.data_trafo.data['tensors']['x_pulses'].shape
@@ -602,7 +599,7 @@ class SourceManager(BaseModelManager):
         for tensor_name in tensor_names:
             tensor = self.data_trafo.data['tensors'][tensor_name]
             input_signature.append(tf.TensorSpec(
-                shape=tensor.shape, dtype=getattr(tf, tensor.dtype)))
+                shape=tensor.shape, dtype=tensor.dtype_tf))
 
         @tf.function(input_signature=tuple(input_signature))
         def model_tensors_function(
@@ -751,7 +748,7 @@ class SourceManager(BaseModelManager):
         """
         num_fit_params = np.sum(fit_parameter_list, dtype=int)
         param_tensor = self.data_trafo.data['tensors'][parameter_tensor_name]
-        param_dtype = getattr(np, param_tensor.dtype)
+        param_dtype = param_tensor.dtype_np
         param_shape = [-1, num_fit_params]
         param_shape_full = [-1, len(fit_parameter_list)]
 
@@ -903,7 +900,7 @@ class SourceManager(BaseModelManager):
         """
         num_fit_params = np.sum(fit_parameter_list, dtype=int)
         param_tensor = self.data_trafo.data['tensors'][parameter_tensor_name]
-        param_dtype = getattr(np, param_tensor.dtype)
+        param_dtype = param_tensor.dtype_np
         param_shape = [-1, num_fit_params]
         param_shape_full = [-1, len(fit_parameter_list)]
 
@@ -1052,7 +1049,7 @@ class SourceManager(BaseModelManager):
         """
         num_fit_params = np.sum(fit_parameter_list, dtype=int)
         param_tensor = self.data_trafo.data['tensors'][parameter_tensor_name]
-        param_dtype = getattr(np, param_tensor.dtype)
+        param_dtype = param_tensor.dtype_np
         param_shape = [-1, num_fit_params]
         param_shape_full = [-1, len(fit_parameter_list)]
 
@@ -1180,7 +1177,7 @@ class SourceManager(BaseModelManager):
         """
         num_fit_params = np.sum(fit_parameter_list, dtype=int)
         param_tensor = self.data_trafo.data['tensors'][parameter_tensor_name]
-        parameter_dtype = getattr(tf, param_tensor.dtype)
+        parameter_dtype = param_tensor.dtype_tf
         param_shape = [-1, num_fit_params]
         param_shape_full = [-1, len(fit_parameter_list)]
 
@@ -1380,7 +1377,7 @@ class SourceManager(BaseModelManager):
         step_size = np.array(step_size)
 
         param_tensor = self.data_trafo.data['tensors'][parameter_tensor_name]
-        parameter_dtype = getattr(tf, param_tensor.dtype)
+        parameter_dtype = param_tensor.dtype_tf
 
         step_size = tf.convert_to_tensor(step_size, dtype=parameter_dtype)
         step_size = tf.reshape(step_size, [1, num_params])
@@ -1505,7 +1502,7 @@ class SourceManager(BaseModelManager):
         # parameter input signature
         parameter_tensor_name = reco_config['parameter_tensor_name']
         param_tensor = self.data_trafo.data['tensors'][parameter_tensor_name]
-        param_dtype = getattr(tf, param_tensor.dtype)
+        param_dtype = param_tensor.dtype_tf
         param_index = self.data_handler.tensors.get_index(
                                                         parameter_tensor_name)
 

--- a/egenerator/model/source/cascade/charge_only.py
+++ b/egenerator/model/source/cascade/charge_only.py
@@ -181,7 +181,7 @@ class ChargeOnlyCascadeModel(Source):
 
         # get parameters tensor dtype
         tensors = self.data_trafo.data['tensors']
-        param_dtype_np = getattr(np, tensors[parameter_tensor_name].dtype)
+        param_dtype_np = tensors[parameter_tensor_name].dtype_np
 
         # -----------------------------------
         # Calculate input values for DOMs

--- a/egenerator/model/source/cascade/charge_quantiles.py
+++ b/egenerator/model/source/cascade/charge_quantiles.py
@@ -225,7 +225,7 @@ class ChargeQuantileCascadeModel(Source):
 
         # get parameters tensor dtype
         tensors = self.data_trafo.data['tensors']
-        param_dtype_np = getattr(np, tensors[parameter_tensor_name].dtype)
+        param_dtype_np = tensors[parameter_tensor_name].dtype_np
 
         # -----------------------------------
         # Calculate input values for DOMs

--- a/egenerator/model/source/cascade/default.py
+++ b/egenerator/model/source/cascade/default.py
@@ -185,7 +185,7 @@ class DefaultCascadeModel(Source):
         print('\t Applying time exclusions:', time_exclusions_exist)
 
         # get parameters tensor dtype
-        param_dtype_np = getattr(np, tensors[parameter_tensor_name].dtype)
+        param_dtype_np = tensors[parameter_tensor_name].dtype_np
 
         # shape: [n_batch, 86, 60, 1]
         dom_charges_true = data_batch_dict['x_dom_charge']

--- a/egenerator/model/source/cascade/systematic.py
+++ b/egenerator/model/source/cascade/systematic.py
@@ -223,7 +223,7 @@ class SystematicsCascadeModel(Source):
 
         # get parameters tensor dtype
         tensors = self.data_trafo.data['tensors']
-        param_dtype_np = getattr(np, tensors[parameter_tensor_name].dtype)
+        param_dtype_np = tensors[parameter_tensor_name].dtype_np
 
         # -----------------------------------
         # Calculate input values for DOMs

--- a/egenerator/model/source/noise/default.py
+++ b/egenerator/model/source/noise/default.py
@@ -146,7 +146,7 @@ class DefaultNoiseModel(Source):
         print('\t Applying time exclusions:', time_exclusions_exist)
 
         # get parameters tensor dtype
-        param_dtype_np = getattr(np, tensors[parameter_tensor_name].dtype)
+        param_dtype_np = tensors[parameter_tensor_name].dtype_np
 
         # shape: [n_pulses, 2]
         pulses = data_batch_dict['x_pulses']

--- a/egenerator/model/source/track/stochastic_segment.py
+++ b/egenerator/model/source/track/stochastic_segment.py
@@ -259,7 +259,7 @@ class StochasticTrackSegmentModel(Source):
 
         # get parameters tensor dtype
         tensors = self.data_trafo.data['tensors']
-        param_dtype_np = getattr(np, tensors[parameter_tensor_name].dtype)
+        param_dtype_np = tensors[parameter_tensor_name].dtype_np
 
         # -----------------------------------
         # Calculate input values for DOMs


### PR DESCRIPTION
This PR is aimed at fixing issue #14. Numpy and tensorflow data types are now handled differently and can be accessed via the added class properties `DataTensor.dtype_tf` and `DataTensor.dtype_np`. Note that `DataTensor.dtype` is kept for serialization purposes.