### PR TITLE
Extend simulation.py. Implement features necessary for the simulation of high energy cascades.

### DIFF
--- a/egenerator/ic3/simulation.py
+++ b/egenerator/ic3/simulation.py
@@ -343,12 +343,13 @@ class EventGeneratorSimulation(icetray.I3ConditionalModule):
 
             # allow for max 1-depth of nested results for mixture model comp.
             if 'latent_var_scale' not in result_tensors:
+                log_warn(
+                    f'Using nested result tensors from \'{self._prefix[:-1]}\' model for time PDF. '
+                    'This is potentially wrong, since this is not the complete time PDF! All models: '
+                    f"{list(result_tensors['nested_results'].keys())}"
+                )
                 result_tensors = result_tensors['nested_results'][
                     self._prefix[:-1]]
-                log_warn(
-                    'Using nested result tensors, this is potentially wrong, '
-                    'since this is not the complete time PDF!'
-                )
 
         cum_scale = np.cumsum(
             result_tensors['latent_var_scale'].numpy(), axis=-1)

--- a/egenerator/ic3/simulation.py
+++ b/egenerator/ic3/simulation.py
@@ -244,6 +244,8 @@ class EventGeneratorSimulation(icetray.I3ConditionalModule):
 
         # Define type of particles that can be simulated as tracks
         self.tracks = [
+            dataclasses.I3Particle.MuMinus,
+            dataclasses.I3Particle.MuPlus,
         ]
 
         # define particles that do not deposit light, in other words
@@ -321,7 +323,7 @@ class EventGeneratorSimulation(icetray.I3ConditionalModule):
             The sampled pulse series map.
         """
 
-        # draw total charge per DOM and cascade
+        # draw total charge per DOM and cascade - shape: (n_cascades, n_string, n_dom, n_model)
         dom_charges = basis_functions.sample_from_negative_binomial(
             rng=self.random_service,
             mu=result_tensors['dom_charges'].numpy(),
@@ -330,7 +332,8 @@ class EventGeneratorSimulation(icetray.I3ConditionalModule):
         )
         # dom_charges = self.random_service.poisson(
         #     result_tensors['dom_charges'].numpy())
-        dom_charges_total = np.sum(dom_charges, axis=0)
+
+        dom_charges_total = np.sum(dom_charges, axis=0)  # sum over cascades
         num_cascades = dom_charges.shape[0]
 
         cascade_times = cascade_sources.numpy()[
@@ -353,7 +356,6 @@ class EventGeneratorSimulation(icetray.I3ConditionalModule):
         latent_var_mu = result_tensors['latent_var_mu'].numpy()
         latent_var_sigma = result_tensors['latent_var_sigma'].numpy()
         latent_var_r = result_tensors['latent_var_r'].numpy()
-
         # for numerical stability:
         cum_scale[..., -1] = 1.00000001
 
@@ -451,7 +453,7 @@ class EventGeneratorSimulation(icetray.I3ConditionalModule):
 
         frame : I3Frame
             Necessary to get additional parameter from frame.
-        
+
         Returns
         -------
         tf.Tensor

--- a/egenerator/ic3/simulation.py
+++ b/egenerator/ic3/simulation.py
@@ -345,10 +345,10 @@ class EventGeneratorSimulation(icetray.I3ConditionalModule):
             if 'latent_var_scale' not in result_tensors:
                 result_tensors = result_tensors['nested_results'][
                     self._prefix[:-1]]
-            log_warn(
-                'Using nested result tensors, this is potentially wrong, '
-                'since this is not the complete time PDF!'
-            )
+                log_warn(
+                    'Using nested result tensors, this is potentially wrong, '
+                    'since this is not the complete time PDF!'
+                )
 
         cum_scale = np.cumsum(
             result_tensors['latent_var_scale'].numpy(), axis=-1)


### PR DESCRIPTION
This PR adds several comments which add features to simulation.py 

- 78c965054988a29bc70d209bbc99ee0be5ea388a allows to simulate daughter particles of (high energy) electrons necessary to simulate the longitudinal extend of cascades
- b5a6adbbe0a5de461c6173f788b18005ab70366f implements a pulse merging which significantly (~ x10) reduces the event size. A similar flag exists for the EHE simulation chain with photonics. Here, I have open questions regarding whether one should mimic the exact sampling resolution of the detector or not. 
- a68da597ddd87e24046223ff2c8e245e7aedea26 allows to store the mean charge prediction for every DOM in a frame.

The remaining commits do minor improvements in logging and commenting. 