### PR TITLE
Allow evaluation in eager mode

### DIFF
--- a/egenerator/utils/learning_rate.py
+++ b/egenerator/utils/learning_rate.py
@@ -58,7 +58,6 @@ class MultiLearningRateScheduler(tf.optimizers.schedules.LearningRateSchedule):
         self.schedulers = schedulers
         self.name = name
 
-    @tf.function
     def __call__(self, step):
 
         step = tf.convert_to_tensor(step)
@@ -86,7 +85,10 @@ class MultiLearningRateScheduler(tf.optimizers.schedules.LearningRateSchedule):
 
             pred_fn_pairs.append(
                 (
-                    step > low and step <= high,
+                    tf.math.logical_and(
+                        tf.math.greater(step, low),
+                        tf.math.less_equal(step, high),
+                    ),
                     lambda: scheduler(step - low),
                 )
             )


### PR DESCRIPTION
Newer tensorflow versions (16.1) seems to require that derived classes from `tf.optimizers.schedules.LearningRateSchedule` are able to run in eager mode. This PR removes the `@tf.function` decorator and ensures that the `__call__` method may be run in eager mode.