### PR TITLE
Force float64

### DIFF
--- a/configs/cascade_11param_noise_ftpv3m.yaml
+++ b/configs/cascade_11param_noise_ftpv3m.yaml
@@ -400,6 +400,7 @@ data_handler_settings: {
         'float_precision': 'float32',
         'add_charge_quantiles': False,
         'discard_pulses_from_excluded_doms': False,
+        'time_window_buffer': 100.,
     },
 
     # --------------------

--- a/configs/cascade_11param_noise_ftpv3m.yaml
+++ b/configs/cascade_11param_noise_ftpv3m.yaml
@@ -293,7 +293,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -307,7 +307,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -321,7 +321,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -335,7 +335,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -349,7 +349,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # define uniform priors
             'uniform_parameters': {
                 'cascade_Absorption': [0.913, 1.087],

--- a/configs/cascade_11param_noise_ftpv3m.yaml
+++ b/configs/cascade_11param_noise_ftpv3m.yaml
@@ -64,7 +64,7 @@ training_settings: {
 
     # Additional keywords to the loss module used for training
     'additional_loss_module_kwargs': {
-        'normalize_by_total_charge': True,
+        'normalize_by_total_charge': False,
     },
 }
 

--- a/configs/cascade_11param_noise_ftpv3m.yaml
+++ b/configs/cascade_11param_noise_ftpv3m.yaml
@@ -253,18 +253,6 @@ data_iterator_settings: {
             # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30253/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
             # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30254/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
 
-            # # MESE NuGen NuE l5 Benchmark Datasets
-            # # Spice3.2.1 variable
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99900/egenerator_99900_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # Spice3.2.1 const
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99901/egenerator_99901_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # SpiceLea variable
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99902/egenerator_99902_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # SpiceLea const
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99903/egenerator_99903_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # Spice3.2.1 variable no fourier
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99911/egenerator_99911_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-
             # # FTPv3m baseline
             # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99915/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # FTPv3m SnowStorm
@@ -384,7 +372,6 @@ data_trafo_settings: {
     'float_precision': 'float64',
     'norm_constant': !!float 1e-6,
     'num_batches': 5000,
-    # 'model_dir': '/cephfs/users/mhuennefeld/data/egenerator/trafo_models/trafo_model_cascade_11param_noise_ftpv3m',
     'model_dir': '/data/user/mhuennefeld/data/egenerator/trafo_models/trafo_model_cascade_11param_noise_ftpv3m',
 }
 

--- a/configs/cascade_11param_noise_ftpv3m.yaml
+++ b/configs/cascade_11param_noise_ftpv3m.yaml
@@ -505,6 +505,7 @@ model_settings: {
                 'charge_distribution_type': 'negative_binomial',
                 'num_latent_models': 10,
                 'float_precision': float32,
+                'float_precision_pdf_cdf': float64,
 
                 # Baseline DOM Angular acceptance
                 'use_constant_baseline_hole_ice': False,

--- a/configs/cascade_7param_noise_ftpv3m.yaml
+++ b/configs/cascade_7param_noise_ftpv3m.yaml
@@ -181,11 +181,11 @@ data_iterator_settings: {
         'num_add_files': 12,
         'num_repetitions': 5,
         'input_data': [
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
         ],
     },
 
@@ -200,11 +200,11 @@ data_iterator_settings: {
         'num_repetitions': 1,
         'pick_random_files_forever': False,
         'input_data': [
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
         ],
     },
 
@@ -221,11 +221,11 @@ data_iterator_settings: {
         'pick_random_files_forever': True,
         'input_data': [
             # Note: The validation data is the same as the training data. Do not pay attention to validation curve!
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
         ],
     },
 
@@ -243,31 +243,19 @@ data_iterator_settings: {
         'input_data': [
 
             # # validation data
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
-
-            # # MESE NuGen NuE l5 Benchmark Datasets
-            # # Spice3.2.1 variable
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99900/egenerator_99900_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # Spice3.2.1 const
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99901/egenerator_99901_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # SpiceLea variable
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99902/egenerator_99902_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # SpiceLea const
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99903/egenerator_99903_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # Spice3.2.1 variable no fourier
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99911/egenerator_99911_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
 
             # FTPv3m baseline
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99915/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99915/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # # FTPv3m SnowStorm
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99916/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99916/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # # FTPv3m SnowStorm Absorption
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99917/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99917/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # # FTPv3m SnowStorm Scattering
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99918/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99918/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # # FTPv3m SnowStorm HoleIce
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99919/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99919/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
 
         ],
     },
@@ -357,7 +345,7 @@ data_trafo_settings: {
     'float_precision': 'float64',
     'norm_constant': !!float 1e-6,
     'num_batches': 5000,
-    'model_dir': '/cephfs/users/mhuennefeld/data/egenerator/trafo_models/trafo_model_cascade_7param_noise_ftpv3m',
+    'model_dir': '/data/user/mhuennefeld/data/egenerator/trafo_models/trafo_model_cascade_7param_noise_ftpv3m',
 }
 
 #----------------------

--- a/configs/cascade_7param_noise_ftpv3m.yaml
+++ b/configs/cascade_7param_noise_ftpv3m.yaml
@@ -373,6 +373,7 @@ data_handler_settings: {
         'float_precision': 'float32',
         'add_charge_quantiles': False,
         'discard_pulses_from_excluded_doms': False,
+        'time_window_buffer': 100.,
     },
 
     # --------------------

--- a/configs/cascade_7param_noise_ftpv3m.yaml
+++ b/configs/cascade_7param_noise_ftpv3m.yaml
@@ -64,7 +64,7 @@ training_settings: {
 
     # Additional keywords to the loss module used for training
     'additional_loss_module_kwargs': {
-        'normalize_by_total_charge': True,
+        'normalize_by_total_charge': False,
     },
 }
 

--- a/configs/cascade_7param_noise_ftpv3m.yaml
+++ b/configs/cascade_7param_noise_ftpv3m.yaml
@@ -480,6 +480,7 @@ model_settings: {
                 'charge_distribution_type': 'negative_binomial',
                 'num_latent_models': 10,
                 'float_precision': float32,
+                'float_precision_pdf_cdf': float64,
 
                 # Baseline DOM Angular acceptance
                 'use_constant_baseline_hole_ice': True,

--- a/configs/cascade_7param_noise_ftpv3m.yaml
+++ b/configs/cascade_7param_noise_ftpv3m.yaml
@@ -286,7 +286,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -300,7 +300,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -314,7 +314,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -328,7 +328,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use

--- a/configs/track_sphere_6param_ftpv3m.yaml
+++ b/configs/track_sphere_6param_ftpv3m.yaml
@@ -387,6 +387,7 @@ data_handler_settings: {
         'float_precision': 'float32',
         'add_charge_quantiles': False,
         'discard_pulses_from_excluded_doms': False,
+        'time_window_buffer': 100.,
     },
 
     # --------------------

--- a/configs/track_sphere_6param_ftpv3m.yaml
+++ b/configs/track_sphere_6param_ftpv3m.yaml
@@ -64,7 +64,7 @@ training_settings: {
 
     # Additional keywords to the loss module used for training
     'additional_loss_module_kwargs': {
-        'normalize_by_total_charge': True,
+        'normalize_by_total_charge': False,
     },
 }
 

--- a/configs/track_sphere_6param_ftpv3m.yaml
+++ b/configs/track_sphere_6param_ftpv3m.yaml
@@ -500,6 +500,7 @@ model_settings: {
                 'charge_distribution_type': 'negative_binomial',
                 'num_latent_models': 10,
                 'float_precision': float32,
+                'float_precision_pdf_cdf': float64,
 
                 # Baseline DOM Angular acceptance
                 'use_constant_baseline_hole_ice': True,

--- a/configs/track_sphere_6param_ftpv3m.yaml
+++ b/configs/track_sphere_6param_ftpv3m.yaml
@@ -380,7 +380,7 @@ data_handler_settings: {
 
     # settings for the data module
     'data_settings':{
-        'pulse_key': 'MCPulses',
+        'pulse_key': 'InIceDSTPulses_masked_doms_only',
         'event_id_key': 'LabelsMCTrackSphere',
         'dom_exclusions_key': BadDomsList,
         'time_exclusions_key': ,
@@ -488,7 +488,7 @@ model_settings: {
                 'keep_prob':,
                 'sphere_radius': 750.,
                 'add_anisotropy_angle': True,
-                'add_dom_angular_acceptance': False,
+                'add_dom_angular_acceptance': True,
                 'add_dom_coordinates': False,
                 'num_local_vars': 0,
                 'scale_charge': True,
@@ -509,7 +509,7 @@ model_settings: {
 
                 # First convolutions
                 'filter_size_list' : [[1, 1], [1, 1], [1, 1], [1, 1], [1, 1], [1, 1]],
-                'num_filters_list' : [25, 100, 100, 100, 100, 42],
+                'num_filters_list' : [50, 200, 200, 200, 200, 42],
                 'method_list' : ['locally_connected',
                                  'convolution', 'convolution', 'convolution',
                                  'convolution', 'convolution',

--- a/configs/track_sphere_6param_ftpv3m.yaml
+++ b/configs/track_sphere_6param_ftpv3m.yaml
@@ -274,7 +274,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -288,7 +288,7 @@ loss_module_settings: [
 
     #     config: {
     #         # the float precision to use
-    #         'float_precision': 'float32',
+    #         'float_precision': 'float64',
     #         # Add normalization terms to llh if True
     #         'add_normalization_term': True,
     #         # choose the loss function to use
@@ -302,7 +302,7 @@ loss_module_settings: [
 
     #     config: {
     #         # the float precision to use
-    #         'float_precision': 'float32',
+    #         'float_precision': 'float64',
     #         # Add normalization terms to llh if True
     #         'add_normalization_term': True,
     #         # choose the loss function to use
@@ -316,7 +316,7 @@ loss_module_settings: [
 
     #     config: {
     #         # the float precision to use
-    #         'float_precision': 'float32',
+    #         'float_precision': 'float64',
     #         # Add normalization terms to llh if True
     #         'add_normalization_term': True,
     #         # choose the loss function to use
@@ -330,7 +330,7 @@ loss_module_settings: [
 
     #     config: {
     #         # the float precision to use
-    #         'float_precision': 'float32',
+    #         'float_precision': 'float64',
     #         # Add normalization terms to llh if True
     #         'add_normalization_term': True,
     #         # choose the loss function to use

--- a/egenerator/data/modules/data/pulse_data.py
+++ b/egenerator/data/modules/data/pulse_data.py
@@ -404,6 +404,14 @@ class PulseDataModule(BaseComponent):
 
         # increase time window by buffer
         buffer = self.configuration.config["time_window_buffer"]
+
+        # non-finite values should only happen if there are no pulses
+        mask_infinite1 = ~np.isfinite(x_time_window[:, 0])
+        mask_infinite2 = ~np.isfinite(x_time_window[:, 1])
+        assert np.all(mask_infinite1 == mask_infinite2)
+        x_time_window[mask_infinite1, 0] = 0
+        x_time_window[mask_infinite1, 1] = 0
+
         if buffer > 0:
             x_time_window[:, 0] -= buffer
             x_time_window[:, 1] += buffer
@@ -642,6 +650,14 @@ class PulseDataModule(BaseComponent):
 
         # increase time window by buffer
         buffer = self.configuration.config["time_window_buffer"]
+
+        # non-finite values should only happen if there are no pulses
+        mask_infinite1 = ~np.isfinite(x_time_window[:, 0])
+        mask_infinite2 = ~np.isfinite(x_time_window[:, 1])
+        assert np.all(mask_infinite1 == mask_infinite2)
+        x_time_window[mask_infinite1, 0] = 0
+        x_time_window[mask_infinite1, 1] = 0
+
         if buffer > 0:
             x_time_window[:, 0] -= buffer
             x_time_window[:, 1] += buffer

--- a/egenerator/data/modules/data/pulse_data.py
+++ b/egenerator/data/modules/data/pulse_data.py
@@ -410,7 +410,7 @@ class PulseDataModule(BaseComponent):
         mask_infinite2 = ~np.isfinite(x_time_window[:, 1])
         assert np.all(mask_infinite1 == mask_infinite2)
         x_time_window[mask_infinite1, 0] = 0
-        x_time_window[mask_infinite1, 1] = 0
+        x_time_window[mask_infinite2, 1] = 0
 
         if buffer > 0:
             x_time_window[:, 0] -= buffer
@@ -656,7 +656,7 @@ class PulseDataModule(BaseComponent):
         mask_infinite2 = ~np.isfinite(x_time_window[:, 1])
         assert np.all(mask_infinite1 == mask_infinite2)
         x_time_window[mask_infinite1, 0] = 0
-        x_time_window[mask_infinite1, 1] = 0
+        x_time_window[mask_infinite2, 1] = 0
 
         if buffer > 0:
             x_time_window[:, 0] -= buffer

--- a/egenerator/loss/default.py
+++ b/egenerator/loss/default.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 from egenerator import misc
 from egenerator.utils import basis_functions
 from egenerator.manager.component import BaseComponent, Configuration
+from egenerator.utils import tf_helpers
 
 
 class DefaultLossModule(BaseComponent):
@@ -362,15 +363,16 @@ class DefaultLossModule(BaseComponent):
             dom_charges_pred = dom_charges_pred * mask_valid
 
         # prevent log(zeros) issues
-        pulse_log_pdf_values = tf.math.log(pulse_pdf_values + self.epsilon)
+        pulse_log_pdf_values = tf_helpers.safe_log(pulse_pdf_values)
 
         # compute unbinned negative likelihood over pulse times with given
         # time pdf: -sum( charge_i * log(pdf_d(t_i)) )
         time_log_likelihood = -pulse_charges * pulse_log_pdf_values
 
         # get poisson likelihood over total charge at a DOM for extendended LLH
-        llh_poisson = dom_charges_pred - dom_charges_true * tf.math.log(
-            dom_charges_pred + self.epsilon
+        llh_poisson = (
+            dom_charges_pred
+            - dom_charges_true * tf_helpers.safe_log(dom_charges_pred)
         )
 
         if sort_loss_terms:
@@ -467,7 +469,7 @@ class DefaultLossModule(BaseComponent):
             ), "Model must deal with time exclusions!"
 
         # prevent log(zeros) issues
-        pulse_log_pdf_values = tf.math.log(pulse_pdf_values + self.epsilon)
+        pulse_log_pdf_values = tf_helpers.safe_log(pulse_pdf_values)
 
         # compute unbinned negative likelihood over pulse times with given
         # time pdf: -sum( charge_i * log(pdf_d(t_i)) )
@@ -613,12 +615,11 @@ class DefaultLossModule(BaseComponent):
         #   charge_i * pdf_i(t_0)^c_0 * (1 - cdf_i(t_0))^(charge_i - c_0)
         #   with t_0 and c_0 the first pulse time and charge at DOM i
         # Shape: [n_pulses_first]
-        eps = self.epsilon
         mpe_log_llh = (
-            tf.math.log(dom_charges_true_pulses + eps)
-            + pulse_charge_first * tf.math.log(pulse_pdf_value_first + eps)
-            + (dom_charges_true_pulses - pulse_charge_first + eps)
-            * tf.math.log(1 - pulse_cdf_value_first + eps)
+            tf_helpers.safe_log(dom_charges_true_pulses)
+            + pulse_charge_first * tf_helpers.safe_log(pulse_pdf_value_first)
+            + (dom_charges_true_pulses - pulse_charge_first)
+            * tf_helpers.safe_log(1 - pulse_cdf_value_first)
         )
         time_loss = -mpe_log_llh
 
@@ -746,7 +747,7 @@ class DefaultLossModule(BaseComponent):
             llh_charge = llh_charge * mask_valid
 
         # prevent log(zeros) issues
-        pulse_log_pdf_values = tf.math.log(pulse_pdf_values + self.epsilon)
+        pulse_log_pdf_values = tf_helpers.safe_log(pulse_pdf_values)
 
         # compute unbinned negative likelihood over pulse times with given
         # time pdf: -sum( charge_i * log(pdf_d(t_i)) )
@@ -861,7 +862,7 @@ class DefaultLossModule(BaseComponent):
             )
 
         # prevent log(zeros) issues
-        pulse_log_pdf_values = tf.math.log(pulse_pdf_values + self.epsilon)
+        pulse_log_pdf_values = tf_helpers.safe_log(pulse_pdf_values)
 
         # compute unbinned negative likelihood over pulse times with given
         # time pdf: -sum( log(pdf_d(t_i)) )
@@ -1421,7 +1422,7 @@ class DefaultLossModule(BaseComponent):
 
         # shape: [n_batch, 86, 60]
         dom_pdf = hits_pred / (event_total + self.epsilon)
-        llh_dom = hits_true * tf.math.log(dom_pdf + self.epsilon)
+        llh_dom = hits_true * tf_helpers.safe_log(dom_pdf)
 
         if sort_loss_terms:
             loss_terms = [

--- a/egenerator/loss/default.py
+++ b/egenerator/loss/default.py
@@ -192,9 +192,20 @@ class DefaultLossModule(BaseComponent):
                 "Sorting of loss terms is unnecessary when reducing to scalar"
             )
 
+        # cast to specified float precision
+        precision = self.configuration.config["config"]["float_precision"]
+        data_batch_dict_cast = {
+            key: tf.cast(value, precision)
+            for key, value in data_batch_dict.items()
+        }
+        result_tensors_cast = {
+            key: tf.cast(value, precision)
+            for key, value in result_tensors.items()
+        }
+
         loss_terms = self.loss_function(
-            data_batch_dict=data_batch_dict,
-            result_tensors=result_tensors,
+            data_batch_dict=data_batch_dict_cast,
+            result_tensors=result_tensors_cast,
             tensors=tensors,
             sort_loss_terms=sort_loss_terms,
         )

--- a/egenerator/loss/default.py
+++ b/egenerator/loss/default.py
@@ -194,18 +194,27 @@ class DefaultLossModule(BaseComponent):
 
         # cast to specified float precision
         precision = self.configuration.config["config"]["float_precision"]
-        data_batch_dict_cast = {
-            key: tf.cast(value, precision)
-            for key, value in data_batch_dict.items()
-            if tf.is_tensor(value)
-            and value.dtype in (tf.float16, tf.float32, tf.float64)
-        }
-        result_tensors_cast = {
-            key: tf.cast(value, precision)
-            for key, value in result_tensors.items()
-            if tf.is_tensor(value)
-            and value.dtype in (tf.float16, tf.float32, tf.float64)
-        }
+        data_batch_dict_cast = {}
+        for key, value in data_batch_dict.items():
+            if tf.is_tensor(value) and value.dtype in (
+                tf.float16,
+                tf.float32,
+                tf.float64,
+            ):
+                data_batch_dict_cast[key] = tf.cast(value, precision)
+            else:
+                data_batch_dict_cast[key] = value
+
+        result_tensors_cast = {}
+        for key, value in result_tensors.items():
+            if tf.is_tensor(value) and value.dtype in (
+                tf.float16,
+                tf.float32,
+                tf.float64,
+            ):
+                result_tensors_cast[key] = tf.cast(value, precision)
+            else:
+                result_tensors_cast[key] = value
 
         loss_terms = self.loss_function(
             data_batch_dict=data_batch_dict_cast,

--- a/egenerator/loss/default.py
+++ b/egenerator/loss/default.py
@@ -197,10 +197,12 @@ class DefaultLossModule(BaseComponent):
         data_batch_dict_cast = {
             key: tf.cast(value, precision)
             for key, value in data_batch_dict.items()
+            if value.dtype in (tf.float16, tf.float32, tf.float64)
         }
         result_tensors_cast = {
             key: tf.cast(value, precision)
             for key, value in result_tensors.items()
+            if value.dtype in (tf.float16, tf.float32, tf.float64)
         }
 
         loss_terms = self.loss_function(

--- a/egenerator/loss/default.py
+++ b/egenerator/loss/default.py
@@ -236,10 +236,13 @@ class DefaultLossModule(BaseComponent):
                 loss_terms[2] = tf.zeros_like(dom_tensor)
 
         if normalize_by_total_charge:
-            total_charge = tf.clip_by_value(
-                tf.reduce_sum(data_batch_dict["x_pulses"][:, 0]),
-                1,
-                float("inf"),
+            total_charge = tf.cast(
+                tf.clip_by_value(
+                    tf.reduce_sum(data_batch_dict["x_pulses"][:, 0]),
+                    1,
+                    float("inf"),
+                ),
+                dtype=precision,
             )
             loss_terms = [loss / total_charge for loss in loss_terms]
 

--- a/egenerator/loss/default.py
+++ b/egenerator/loss/default.py
@@ -197,12 +197,14 @@ class DefaultLossModule(BaseComponent):
         data_batch_dict_cast = {
             key: tf.cast(value, precision)
             for key, value in data_batch_dict.items()
-            if value.dtype in (tf.float16, tf.float32, tf.float64)
+            if tf.is_tensor(value)
+            and value.dtype in (tf.float16, tf.float32, tf.float64)
         }
         result_tensors_cast = {
             key: tf.cast(value, precision)
             for key, value in result_tensors.items()
-            if value.dtype in (tf.float16, tf.float32, tf.float64)
+            if tf.is_tensor(value)
+            and value.dtype in (tf.float16, tf.float32, tf.float64)
         }
 
         loss_terms = self.loss_function(

--- a/egenerator/loss/snowstorm.py
+++ b/egenerator/loss/snowstorm.py
@@ -195,6 +195,10 @@ class SnowstormPriorLossModule(BaseComponent):
         normalization = np.exp(exp_factor)
 
         def loss_excess(scaled_excess):
+            scaled_excess = tf.cast(
+                scaled_excess,
+                self.configuration.config["config"]["float_precision"],
+            )
             return tf.exp((scaled_excess + 1) * exp_factor) - normalization
 
         loss = tf.where(
@@ -314,6 +318,7 @@ class SnowstormPriorLossModule(BaseComponent):
                 fourier_values,
                 mu=tf.zeros_like(fourier_sigmas),
                 sigma=fourier_sigmas,
+                dtype=self.configuration.config["config"]["float_precision"],
             )
 
             # we will use the negative log likelihood as loss

--- a/egenerator/manager/reconstruction/modules/reconstruction.py
+++ b/egenerator/manager/reconstruction/modules/reconstruction.py
@@ -166,11 +166,17 @@ class Reconstruction:
         # choose reconstruction method depending on the optimizer interface
         if reco_optimizer_interface.lower() == "scipy":
 
+            # choose function according to jac (default: True)
+            scipy_loss_function = loss_and_gradients_function
+            if "jac" in scipy_optimizer_settings:
+                if not scipy_optimizer_settings["jac"]:
+                    scipy_loss_function = self.parameter_loss_function
+
             def reconstruction_method(data_batch, seed_tensor):
                 return manager.reconstruct_events(
                     data_batch,
                     loss_module,
-                    loss_and_gradients_function=loss_and_gradients_function,
+                    loss_and_gradients_function=scipy_loss_function,
                     fit_parameter_list=fit_parameter_list,
                     minimize_in_trafo_space=minimize_in_trafo_space,
                     seed=seed_tensor,

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -635,7 +635,9 @@ class SourceManager(BaseModelManager):
             x_pulses_ids=tf.convert_to_tensor([[0, 0, 0, 0]]),
             x_dom_exclusions=tf.ones([0, 86, 60, 1], dtype=tf.bool),
             x_dom_charge=tf.ones([0, 86, 60, 1], dtype=param_dtype),
-            x_time_window=tf.convert_to_tensor([[9000, 9001]], dtype=tw_dtype),
+            x_time_window=tf.convert_to_tensor(
+                [[6000, 15000]], dtype=tw_dtype
+            ),
             x_time_exclusions=tf.convert_to_tensor(
                 [[0, 0]], dtype=t_exclusions_dtype
             ),

--- a/egenerator/model/multi_source/base.py
+++ b/egenerator/model/multi_source/base.py
@@ -459,7 +459,7 @@ class MultiSource(Source):
         # normalize time exclusion sum: divide by total charge at DOM
         if time_exclusions_exist:
             dom_cdf_exclusion_sum = tf_helpers.safe_cdf_clip(
-                dom_cdf_exclusion_sum / dom_charges
+                dom_cdf_exclusion_sum / (dom_charges + self.epsilon)
             )
 
             result_tensors["dom_cdf_exclusion_sum"] = dom_cdf_exclusion_sum

--- a/egenerator/model/source/base.py
+++ b/egenerator/model/source/base.py
@@ -116,11 +116,11 @@ class Source(Model):
 
         elif "sources" in config:
             model_precisions = []
-            for source in config["sources"]:
+            for _, base_source in config["sources"].items():
                 model_precisions.append(
-                    self.sub_components[source].configuration.config["config"][
-                        "float_precision"
-                    ]
+                    self.sub_components[base_source].configuration.config[
+                        "config"
+                    ]["float_precision"]
                 )
             model_precisions = np.unique(model_precisions)
             if len(model_precisions) > 1:

--- a/egenerator/model/source/base.py
+++ b/egenerator/model/source/base.py
@@ -405,6 +405,7 @@ class Source(Model):
         tw_exclusions_ids=None,
         strings=slice(None),
         doms=slice(None),
+        dtype="float64",
         **kwargs
     ):
         """Compute CDF values at x for given result_tensors
@@ -457,6 +458,9 @@ class Source(Model):
             The doms to slice the PDF for.
             If None, all doms are used.
             Shape: [n_doms]
+        dtype : str, optional
+            The data type of the output array.
+            Default: 'float64'
         **kwargs
             Keyword arguments.
 
@@ -474,7 +478,12 @@ class Source(Model):
             If asymmetric Gaussian latent variables are not present in
             `result_tensors` dictionary.
         """
-        eps = 1e-7
+        if dtype == "float64":
+            eps = 1e-15
+        elif dtype == "float32":
+            eps = 1e-7
+        else:
+            raise ValueError(f"Invalid dtype: {dtype}")
 
         x_orig = np.atleast_1d(x)
         assert len(x_orig.shape) == 1, x_orig.shape
@@ -521,7 +530,11 @@ class Source(Model):
 
         # shape: [n_events, n_strings, n_doms, n_components, n_points]
         mixture_cdf = basis_functions.asymmetric_gauss_cdf(
-            x=x, mu=mu, sigma=sigma, r=r
+            x=x,
+            mu=mu,
+            sigma=sigma,
+            r=r,
+            dtype=dtype,
         )
 
         # uniformly scale up pdf values due to excluded regions
@@ -573,6 +586,7 @@ class Source(Model):
                             sigma[ids[0], ids[1], ids[2]], [1, 1, -1]
                         ),
                         r=np.reshape(r[ids[0], ids[1], ids[2]], [1, 1, -1]),
+                        dtype=dtype,
                     )
                     * np.reshape(scale[ids[0], ids[1], ids[2]], [1, 1, -1]),
                     axis=2,
@@ -585,7 +599,7 @@ class Source(Model):
 
                 cdf_values[ids[0], ids[1], ids[2]] -= cdf_excluded
 
-            eps = 1e-3
+            eps = 1e-6
             if (cdf_values < 0 - eps).any():
                 self._logger.warning(
                     "CDF values below zero: {}".format(
@@ -609,6 +623,7 @@ class Source(Model):
         tw_exclusions_ids=None,
         strings=slice(None),
         doms=slice(None),
+        dtype="float64",
         **kwargs
     ):
         """Compute PDF values at x for given result_tensors
@@ -678,7 +693,12 @@ class Source(Model):
             If asymmetric Gaussian latent variables are not present in
             `result_tensors` dictionary.
         """
-        eps = 1e-7
+        if dtype == "float64":
+            eps = 1e-15
+        elif dtype == "float32":
+            eps = 1e-7
+        else:
+            raise ValueError(f"Invalid dtype: {dtype}")
 
         x_orig = np.atleast_1d(x)
         assert len(x_orig.shape) == 1, x_orig.shape
@@ -722,7 +742,11 @@ class Source(Model):
 
         # shape: [n_events, n_strings, n_doms, n_components, n_points]
         mixture_pdf = basis_functions.asymmetric_gauss(
-            x=x, mu=mu, sigma=sigma, r=r
+            x=x,
+            mu=mu,
+            sigma=sigma,
+            r=r,
+            dtype=dtype,
         )
 
         # uniformly scale up pdf values due to excluded regions

--- a/egenerator/model/source/cascade/default.py
+++ b/egenerator/model/source/cascade/default.py
@@ -567,8 +567,8 @@ class DefaultCascadeModel(Source):
 
         # force positive and min values
         latent_scale = tf.nn.elu(latent_scale) + 1.00001
-        latent_r = tf.nn.elu(latent_r) + 1.001
-        latent_sigma = tf.nn.elu(latent_sigma) + 1.001
+        latent_r = tf.nn.elu(latent_r) + 1.0001
+        latent_sigma = tf.nn.elu(latent_sigma) + 1.0001
 
         # normalize scale to sum to 1
         latent_scale /= tf.reduce_sum(latent_scale, axis=-1, keepdims=True)

--- a/egenerator/model/source/cascade/default.py
+++ b/egenerator/model/source/cascade/default.py
@@ -621,14 +621,14 @@ class DefaultCascadeModel(Source):
                 mu=tw_latent_mu,
                 sigma=tw_latent_sigma,
                 r=tw_latent_r,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
             tw_cdf_stop = basis_functions.tf_asymmetric_gauss_cdf(
                 x=t_exclusions[:, 1],
                 mu=tw_latent_mu,
                 sigma=tw_latent_sigma,
                 r=tw_latent_r,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
 
             # shape: [n_tw, n_models]
@@ -784,7 +784,7 @@ class DefaultCascadeModel(Source):
                             mu=dom_charges,
                             sigma=dom_charges_sigma,
                             r=dom_charges_r,
-                            dtype="float64",
+                            dtype=config["float_precision_pdf_cdf"],
                         )
                     ),
                     dtype=config["float_precision"],
@@ -835,7 +835,7 @@ class DefaultCascadeModel(Source):
                     x=dom_charges_true,
                     mu=dom_charges,
                     alpha=dom_charges_alpha,
-                    dtype="float64",
+                    dtype=config["float_precision_pdf_cdf"],
                 ),
                 dtype=config["float_precision"],
             )
@@ -890,8 +890,7 @@ class DefaultCascadeModel(Source):
         # -------------------------------------------
 
         pulse_latent_scale = tf.cast(
-            pulse_latent_scale,
-            dtype="float64",
+            pulse_latent_scale, dtype=config["float_precision_pdf_cdf"]
         )
 
         # [n_pulses, 1] * [n_pulses, n_models] = [n_pulses, n_models]
@@ -901,7 +900,7 @@ class DefaultCascadeModel(Source):
                 mu=pulse_latent_mu,
                 sigma=pulse_latent_sigma,
                 r=pulse_latent_r,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
             * pulse_latent_scale
         )
@@ -911,7 +910,7 @@ class DefaultCascadeModel(Source):
                 mu=pulse_latent_mu,
                 sigma=pulse_latent_sigma,
                 r=pulse_latent_r,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
             * pulse_latent_scale
         )

--- a/egenerator/model/source/cascade/default.py
+++ b/egenerator/model/source/cascade/default.py
@@ -772,16 +772,15 @@ class DefaultCascadeModel(Source):
             # shape: [n_batch, 86, 60, 1]
             dom_charges_llh = tf.where(
                 dom_charges_true > charge_threshold,
-                tf.math.log(
+                tf_helpers.safe_log(
                     basis_functions.tf_asymmetric_gauss(
                         x=dom_charges_true,
                         mu=dom_charges,
                         sigma=dom_charges_sigma,
                         r=dom_charges_r,
                     )
-                    + self.epsilon
                 ),
-                dom_charges_true * tf.math.log(dom_charges + self.epsilon)
+                dom_charges_true * tf_helpers.safe_log(dom_charges)
                 - dom_charges,
             )
 

--- a/egenerator/model/source/cascade/default.py
+++ b/egenerator/model/source/cascade/default.py
@@ -890,7 +890,8 @@ class DefaultCascadeModel(Source):
         # -------------------------------------------
 
         pulse_latent_scale = tf.cast(
-            pulse_latent_scale, dtype=config["float_precision"]
+            pulse_latent_scale,
+            dtype="float64",
         )
 
         # [n_pulses, 1] * [n_pulses, n_models] = [n_pulses, n_models]

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -961,6 +961,8 @@ class EnteringSphereInfTrack(Source):
         # Apply Asymmetric Gaussian Mixture Model
         # -------------------------------------------
 
+        pulse_latent_scale = tf.cast(pulse_latent_scale, "float64")
+
         # [n_pulses, 1] * [n_pulses, n_models] = [n_pulses, n_models]
         pulse_pdf_values = (
             basis_functions.tf_asymmetric_gauss(

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -659,7 +659,7 @@ class EnteringSphereInfTrack(Source):
         # features.
         t_seed = (
             np.r_[
-                [0, 100, 8000, 14000, 4000, 800, 300, 1000, 400, 2000],
+                [0, -100, 100, 8000, 4000, 800, 300, 1000, 400, 2000],
                 np.random.RandomState(42).uniform(0, 14000, max(1, n_models)),
             ][:n_models]
             * t_scale

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -263,9 +263,9 @@ class EnteringSphereInfTrack(Source):
 
         # calculate normalized vector to entry point
         # shape: [n_batch, 1, 1, 1]
-        e_dir_x = -tf.sin(e_zenith) * tf.cos(e_azimuth)
-        e_dir_y = -tf.sin(e_zenith) * tf.sin(e_azimuth)
-        e_dir_z = -tf.cos(e_zenith)
+        e_dir_x = tf.sin(e_zenith) * tf.cos(e_azimuth)
+        e_dir_y = tf.sin(e_zenith) * tf.sin(e_azimuth)
+        e_dir_z = tf.cos(e_zenith)
 
         # calculate entry position on a sphere of the given radius
         # shape: [n_batch, 1, 1, 1]

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -372,7 +372,7 @@ class EnteringSphereInfTrack(Source):
         # calculate opening angle of track direction and displacement vector
         # from the closest approach point to the DOM
         opening_angle_closest = angles.get_angle(
-            tf.stack([dir_x, dir_y, dir_z], axis=-1),
+            tf.concat([dir_x, dir_y, dir_z], axis=-1),
             tf.concat([dx_inf, dy_inf, dz_inf], axis=-1),
         )[..., tf.newaxis]
 

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -80,7 +80,7 @@ class EnteringSphereInfTrack(Source):
                 for i in range(num):
                     parameter_names.append(param_name.format(i))
 
-        num_inputs = 13 + num_snowstorm_params
+        num_inputs = 21 + num_snowstorm_params
 
         if config["add_anisotropy_angle"]:
             num_inputs += 2

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -639,9 +639,9 @@ class EnteringSphereInfTrack(Source):
         latent_mu = dt_geometry + t_seed + factor_mu * latent_mu
 
         # force positive and min values
-        latent_scale = tf.math.exp(latent_scale)
-        latent_r = tf.math.exp(latent_r)
-        latent_sigma = tf.math.exp(latent_sigma) + 0.0001
+        latent_scale = tf.nn.elu(latent_scale) + 1.00001
+        latent_r = tf.nn.elu(latent_r) + 1.0001
+        latent_sigma = tf.nn.elu(latent_sigma) + 1.0001
 
         # normalize scale to sum to 1
         latent_scale /= tf.reduce_sum(latent_scale, axis=-1, keepdims=True)

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -849,7 +849,7 @@ class EnteringSphereInfTrack(Source):
             dom_charges_llh = tf.where(
                 dom_charges_true > charge_threshold,
                 tf.cast(
-                    tf.math.log(
+                    tf_helpers.safe_log(
                         basis_functions.tf_asymmetric_gauss(
                             x=dom_charges_true,
                             mu=dom_charges,
@@ -857,11 +857,10 @@ class EnteringSphereInfTrack(Source):
                             r=dom_charges_r,
                             dtype="float64",
                         )
-                        + self.epsilon
                     ),
                     config["float_precision"],
                 ),
-                dom_charges_true * tf.math.log(dom_charges + self.epsilon)
+                dom_charges_true * tf_helpers.safe_log(dom_charges)
                 - dom_charges,
             )
 

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -694,14 +694,14 @@ class EnteringSphereInfTrack(Source):
                 mu=tw_latent_mu,
                 sigma=tw_latent_sigma,
                 r=tw_latent_r,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
             tw_cdf_stop = basis_functions.tf_asymmetric_gauss_cdf(
                 x=t_exclusions[:, 1],
                 mu=tw_latent_mu,
                 sigma=tw_latent_sigma,
                 r=tw_latent_r,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
 
             # shape: [n_tw, n_models]
@@ -855,7 +855,7 @@ class EnteringSphereInfTrack(Source):
                             mu=dom_charges,
                             sigma=dom_charges_sigma,
                             r=dom_charges_r,
-                            dtype="float64",
+                            dtype=config["float_precision_pdf_cdf"],
                         )
                     ),
                     config["float_precision"],
@@ -905,7 +905,7 @@ class EnteringSphereInfTrack(Source):
                 x=dom_charges_true,
                 mu=dom_charges,
                 alpha=dom_charges_alpha,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
             dom_charges_llh = tf.cast(
                 dom_charges_llh, config["float_precision"]
@@ -969,7 +969,7 @@ class EnteringSphereInfTrack(Source):
                 mu=pulse_latent_mu,
                 sigma=pulse_latent_sigma,
                 r=pulse_latent_r,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
             * pulse_latent_scale
         )
@@ -979,7 +979,7 @@ class EnteringSphereInfTrack(Source):
                 mu=pulse_latent_mu,
                 sigma=pulse_latent_sigma,
                 r=pulse_latent_r,
-                dtype="float64",
+                dtype=config["float_precision_pdf_cdf"],
             )
             * pulse_latent_scale
         )

--- a/egenerator/utils/basis_functions.py
+++ b/egenerator/utils/basis_functions.py
@@ -5,7 +5,49 @@ from scipy import stats
 from scipy.integrate import quad
 
 
-def tf_gauss(x, mu, sigma):
+def cast(dtype, *args):
+    """Cast all input arguments to the provided data type.
+
+    Parameters
+    ----------
+    dtype : str
+        The data type to cast the inputs to.
+        If None, no casting is performed.
+    *args : array_like
+        The input arguments to cast.
+
+    Returns
+    -------
+    array_like
+        The casted input arguments.
+    """
+    if dtype is None:
+        return args
+    return tuple(np.array(arg, dtype=dtype) for arg in args)
+
+
+def tf_cast(dtype, *args):
+    """Cast all input arguments to the provided data type.
+
+    Parameters
+    ----------
+    dtype : str
+        The data type to cast the inputs to.
+        If None, no casting is performed.
+    *args : tf.Tensor
+        The input arguments to cast.
+
+    Returns
+    -------
+    tf.Tensor
+        The casted input arguments.
+    """
+    if dtype is None:
+        return args
+    return tuple(tf.cast(arg, dtype) for arg in args)
+
+
+def tf_gauss(x, mu, sigma, dtype=None):
     """Gaussian PDF
 
     Parameters
@@ -16,18 +58,22 @@ def tf_gauss(x, mu, sigma):
         Mu parameter of Gaussian.
     sigma : tf.Tensor
         Sigma parameter of Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The Gaussian PDF evaluated at x
     """
+    x, mu, sigma = tf_cast(dtype, x, mu, sigma)
     return (
         tf.exp(-0.5 * ((x - mu) / sigma) ** 2) / (2 * np.pi * sigma**2) ** 0.5
     )
 
 
-def gauss(x, mu, sigma):
+def gauss(x, mu, sigma, dtype=None):
     """Gaussian PDF
 
     Parameters
@@ -38,18 +84,22 @@ def gauss(x, mu, sigma):
         Mu parameter of Gaussian.
     sigma : array_like
         Sigma parameter of Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The Gaussian PDF evaluated at x
     """
+    x, mu, sigma = cast(dtype, x, mu, sigma)
     return (
         np.exp(-0.5 * ((x - mu) / sigma) ** 2) / (2 * np.pi * sigma**2) ** 0.5
     )
 
 
-def tf_log_gauss(x, mu, sigma):
+def tf_log_gauss(x, mu, sigma, dtype=None):
     """Log Gaussian PDF
 
     Parameters
@@ -60,17 +110,21 @@ def tf_log_gauss(x, mu, sigma):
         Mu parameter of Gaussian.
     sigma : tf.Tensor
         Sigma parameter of Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The Gaussian PDF evaluated at x
     """
+    x, mu, sigma = tf_cast(dtype, x, mu, sigma)
     norm = np.log(np.sqrt(2 * np.pi))
     return -0.5 * ((x - mu) / sigma) ** 2 - tf.math.log(sigma) - norm
 
 
-def log_gauss(x, mu, sigma):
+def log_gauss(x, mu, sigma, dtype=None):
     """Log Gaussian PDF
 
     Parameters
@@ -81,17 +135,21 @@ def log_gauss(x, mu, sigma):
         Mu parameter of Gaussian.
     sigma : array_like
         Sigma parameter of Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The Gaussian PDF evaluated at x
     """
+    x, mu, sigma = cast(dtype, x, mu, sigma)
     norm = np.log(np.sqrt(2 * np.pi))
     return -0.5 * ((x - mu) / sigma) ** 2 - np.log(sigma) - norm
 
 
-def tf_log_asymmetric_gauss(x, mu, sigma, r):
+def tf_log_asymmetric_gauss(x, mu, sigma, r, dtype=None):
     """Asymmetric Log Gaussian PDF
 
     Parameters
@@ -104,12 +162,16 @@ def tf_log_asymmetric_gauss(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : tf.Tensor
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The asymmetric Gaussian PDF evaluated at x
     """
+    x, mu, sigma, r = tf_cast(dtype, x, mu, sigma, r)
     norm = tf.math.log(2.0 / (tf.sqrt(2 * np.pi * sigma**2) * (r + 1)))
     exp = tf.where(
         x < mu,
@@ -119,7 +181,7 @@ def tf_log_asymmetric_gauss(x, mu, sigma, r):
     return norm + exp
 
 
-def log_asymmetric_gauss(x, mu, sigma, r):
+def log_asymmetric_gauss(x, mu, sigma, r, dtype=None):
     """Asymmetric Log Gaussian PDF
 
     Parameters
@@ -132,12 +194,16 @@ def log_asymmetric_gauss(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : array_like
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The asymmetric Gaussian PDF evaluated at x
     """
+    x, mu, sigma, r = cast(dtype, x, mu, sigma, r)
     norm = np.log(2.0 / (np.sqrt(2 * np.pi * sigma**2) * (r + 1)))
     exp = np.where(
         x < mu,
@@ -147,7 +213,7 @@ def log_asymmetric_gauss(x, mu, sigma, r):
     return norm + exp
 
 
-def tf_asymmetric_gauss(x, mu, sigma, r):
+def tf_asymmetric_gauss(x, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian PDF
 
     Parameters
@@ -160,12 +226,16 @@ def tf_asymmetric_gauss(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : tf.Tensor
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The asymmetric Gaussian PDF evaluated at x
     """
+    x, mu, sigma, r = tf_cast(dtype, x, mu, sigma, r)
     norm = 2.0 / (tf.sqrt(2 * np.pi * sigma**2) * (r + 1))
     exp = tf.where(
         x < mu,
@@ -175,7 +245,7 @@ def tf_asymmetric_gauss(x, mu, sigma, r):
     return norm * exp
 
 
-def asymmetric_gauss(x, mu, sigma, r):
+def asymmetric_gauss(x, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian PDF
 
     Parameters
@@ -188,12 +258,16 @@ def asymmetric_gauss(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : array_like
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The asymmetric Gaussian PDF evaluated at x
     """
+    x, mu, sigma, r = cast(dtype, x, mu, sigma, r)
     norm = 2.0 / (np.sqrt(2 * np.pi * sigma**2) * (r + 1))
     exp = np.where(
         x < mu,
@@ -203,7 +277,7 @@ def asymmetric_gauss(x, mu, sigma, r):
     return norm * exp
 
 
-def tf_asymmetric_gauss_cdf(x, mu, sigma, r):
+def tf_asymmetric_gauss_cdf(x, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian CDF
 
     Parameters
@@ -216,12 +290,16 @@ def tf_asymmetric_gauss_cdf(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : tf.Tensor
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The asymmetric Gaussian CDF evaluated at x
     """
+    x, mu, sigma, r = tf_cast(dtype, x, mu, sigma, r)
     norm = 1.0 / (r + 1)
     exp = tf.where(
         x < mu,
@@ -231,7 +309,7 @@ def tf_asymmetric_gauss_cdf(x, mu, sigma, r):
     return norm * exp
 
 
-def asymmetric_gauss_cdf(x, mu, sigma, r):
+def asymmetric_gauss_cdf(x, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian CDF
 
     Parameters
@@ -244,12 +322,16 @@ def asymmetric_gauss_cdf(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : array_like
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The asymmetric Gaussian CDF evaluated at x
     """
+    x, mu, sigma, r = cast(dtype, x, mu, sigma, r)
     norm = 1.0 / (r + 1)
     exp = np.where(
         x < mu,
@@ -259,7 +341,7 @@ def asymmetric_gauss_cdf(x, mu, sigma, r):
     return norm * exp
 
 
-def tf_asymmetric_gauss_ppf(q, mu, sigma, r):
+def tf_asymmetric_gauss_ppf(q, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian PPF
 
     Parameters
@@ -272,12 +354,16 @@ def tf_asymmetric_gauss_ppf(q, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : tf.Tensor
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The asymmetric Gaussian PPF evaluated at q
     """
+    q, mu, sigma, r = tf_cast(dtype, q, mu, sigma, r)
     return tf.where(
         q < 1.0 / (r + 1),
         mu + np.sqrt(2) * sigma * tf.math.erfinv(q * (r + 1) - 1),
@@ -285,7 +371,7 @@ def tf_asymmetric_gauss_ppf(q, mu, sigma, r):
     )
 
 
-def asymmetric_gauss_ppf(q, mu, sigma, r):
+def asymmetric_gauss_ppf(q, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian PPF
 
     Parameters
@@ -298,12 +384,16 @@ def asymmetric_gauss_ppf(q, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : array_like
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The asymmetric Gaussian PPF evaluated at q
     """
+    q, mu, sigma, r = cast(dtype, q, mu, sigma, r)
     return np.where(
         q < 1.0 / (r + 1),
         mu + np.sqrt(2) * sigma * special.erfinv(q * (r + 1) - 1),
@@ -311,7 +401,9 @@ def asymmetric_gauss_ppf(q, mu, sigma, r):
     )
 
 
-def tf_log_negative_binomial(x, mu, alpha, add_normalization_term=False):
+def tf_log_negative_binomial(
+    x, mu, alpha, add_normalization_term=False, dtype=None
+):
     """Computes the logarithm of the negative binomial PDF
 
     The parameterization chosen here is defined by the mean mu and
@@ -339,12 +431,17 @@ def tf_log_negative_binomial(x, mu, alpha, add_normalization_term=False):
         binomial distribution only has a proper normalization for integer x.
         For real-valued x the negative binomial is not properly normalized and
         hence adding the normalization term does not help.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         Logarithm of the negative binomal PDF evaluated at x.
     """
+    x, mu, alpha = tf_cast(dtype, x, mu, alpha)
+
     inv_alpha = 1.0 / alpha
     alpha_mu = alpha * mu
 
@@ -360,7 +457,9 @@ def tf_log_negative_binomial(x, mu, alpha, add_normalization_term=False):
     return gamma_terms + term1 + term2
 
 
-def log_negative_binomial(x, mu, alpha, add_normalization_term=False):
+def log_negative_binomial(
+    x, mu, alpha, add_normalization_term=False, dtype=None
+):
     """Computes the logarithm of the negative binomial PDF
 
     The parameterization chosen here is defined by the mean mu and
@@ -395,12 +494,17 @@ def log_negative_binomial(x, mu, alpha, add_normalization_term=False):
         binomial distribution only has a proper normalization for integer x.
         For real-valued x the negative binomial is not properly normalized and
         hence adding the normalization term does not help.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         Logarithm of the negative binomal PDF evaluated at x.
     """
+    x, mu, alpha = cast(dtype, x, mu, alpha)
+
     inv_alpha = 1.0 / alpha
     alpha_mu = alpha * mu
 
@@ -508,7 +612,7 @@ def sample_from_negative_binomial(
     return rng.negative_binomial(r, p, size=size)
 
 
-def negative_binomial_cdf(x, mu, alpha_or_var, param_is_alpha):
+def negative_binomial_cdf(x, mu, alpha_or_var, param_is_alpha, dtype=None):
     """Computes the CDF of the negative binomial PDF
 
     The parameterization chosen here is defined by the mean mu and
@@ -537,19 +641,23 @@ def negative_binomial_cdf(x, mu, alpha_or_var, param_is_alpha):
     param_is_alpha : bool
         If True, the parameter passed as `alpha_or_var` is alpha.
         If False, the parameter passed as `alpha_or_var` is the variance.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         CDF of the negative binomal PDF evaluated at x.
     """
+    x, mu, alpha_or_var = cast(dtype, x, mu, alpha_or_var)
     p, r = convert_neg_binomial_params(
         mu=mu, alpha_or_var=alpha_or_var, param_is_alpha=param_is_alpha
     )
     return stats.nbinom(r, p).cdf(x)
 
 
-def negative_binomial_ppf(q, mu, alpha_or_var, param_is_alpha):
+def negative_binomial_ppf(q, mu, alpha_or_var, param_is_alpha, dtype=None):
     """Computes the PPF of the negative binomial PDF
 
     The parameterization chosen here is defined by the mean mu and
@@ -578,19 +686,23 @@ def negative_binomial_ppf(q, mu, alpha_or_var, param_is_alpha):
     param_is_alpha : bool
         If True, the parameter passed as `alpha_or_var` is alpha.
         If False, the parameter passed as `alpha_or_var` is the variance.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         PPF of the negative binomal PDF evaluated at x.
     """
+    mu, alpha_or_var = cast(dtype, mu, alpha_or_var)
     p, r = convert_neg_binomial_params(
         mu=mu, alpha_or_var=alpha_or_var, param_is_alpha=param_is_alpha
     )
     return stats.nbinom(r, p).ppf(q)
 
 
-def tf_rayleigh(x, sigma):
+def tf_rayleigh(x, sigma, dtype=None):
     """Computes Rayleigh PDF
 
     Parameters
@@ -599,16 +711,20 @@ def tf_rayleigh(x, sigma):
         The input tensor.
     sigma : tf.Tensor
         The sigma parameter of the Rayleigh distribution.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The PDF of the Rayleigh distribution evaluated at x.
     """
+    x, sigma = tf_cast(dtype, x, sigma)
     return x / (sigma**2) * tf.exp(-0.5 * (x / sigma) ** 2)
 
 
-def rayleigh(x, sigma):
+def rayleigh(x, sigma, dtype=None):
     """Computes Rayleigh PDF
 
     Parameters
@@ -617,16 +733,20 @@ def rayleigh(x, sigma):
         The input tensor.
     sigma : array_like
         The sigma parameter of the Rayleigh distribution.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The PDF of the Rayleigh distribution evaluated at x.
     """
+    x, sigma = cast(dtype, x, sigma)
     return x / (sigma**2) * np.exp(-0.5 * (x / sigma) ** 2)
 
 
-def tf_rayleigh_cdf(x, sigma):
+def tf_rayleigh_cdf(x, sigma, dtype=None):
     """Computes CDF of Rayleigh distribution.
 
     Parameters
@@ -635,16 +755,20 @@ def tf_rayleigh_cdf(x, sigma):
         The input tensor.
     sigma : tf.Tensor
         The sigma parameter of the Rayleigh distribution.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The CDF of the Rayleigh distribution evaluated at x.
     """
+    x, sigma = tf_cast(dtype, x, sigma)
     return 1 - tf.exp(-0.5 * (x / sigma) ** 2)
 
 
-def rayleigh_cdf(x, sigma):
+def rayleigh_cdf(x, sigma, dtype=None):
     """Computes CDF of Rayleigh distribution.
 
     Parameters
@@ -653,16 +777,20 @@ def rayleigh_cdf(x, sigma):
         The input tensor.
     sigma : array_like
         The sigma parameter of the Rayleigh distribution.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The CDF of the Rayleigh distribution evaluated at x.
     """
+    x, sigma = cast(dtype, x, sigma)
     return 1 - np.exp(-0.5 * (x / sigma) ** 2)
 
 
-def von_mises_pdf(x, sigma, kent_min=np.deg2rad(7)):
+def von_mises_pdf(x, sigma, kent_min=np.deg2rad(7), dtype=None):
     """Computes the von Mises-Fisher PDF on the sphere
 
     The PDF is defined and normalized in cartesian
@@ -679,12 +807,16 @@ def von_mises_pdf(x, sigma, kent_min=np.deg2rad(7)):
         The value over which to use the von Mises-Fisher distribution.
         Underneath, a 2D Gaussian approximation is used for more numerical
         stability.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The PDF evaluated at the provided opening angles x.
     """
+    x, sigma = cast(dtype, x, sigma)
     x = np.atleast_1d(x)
     sigma = np.atleast_1d(sigma)
 
@@ -708,7 +840,7 @@ def von_mises_pdf(x, sigma, kent_min=np.deg2rad(7)):
     return result
 
 
-def von_mises_in_dPsi_pdf(x, sigma, kent_min=np.deg2rad(7)):
+def von_mises_in_dPsi_pdf(x, sigma, kent_min=np.deg2rad(7), dtype=None):
     """Computes the von Mises-Fisher PDF on the sphere
 
     The PDF is defined and normalized in the opening angle dPsi.
@@ -723,12 +855,17 @@ def von_mises_in_dPsi_pdf(x, sigma, kent_min=np.deg2rad(7)):
         The value over which to use the von Mises-Fisher distribution.
         Underneath, a 2D Gaussian approximation is used for more numerical
         stability.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The PDF evaluated at the provided opening angles x.
     """
+    x, sigma = cast(dtype, x, sigma)
+
     # switching coordinates from (dx1, dx2) to spherical
     # coordinates (dPsi, phi) means that we have to include
     # the jakobi determinant sin dPsi
@@ -741,7 +878,7 @@ def von_mises_in_dPsi_pdf(x, sigma, kent_min=np.deg2rad(7)):
     )
 
 
-def von_mises_in_dPsi_cdf(x, sigma, kent_min=np.deg2rad(7)):
+def von_mises_in_dPsi_cdf(x, sigma, kent_min=np.deg2rad(7), dtype=None):
     """Computes the von Mises-Fisher CDF on the sphere
 
     The underlying PDF is defined and normalized in the opening angle dPsi.
@@ -758,6 +895,9 @@ def von_mises_in_dPsi_cdf(x, sigma, kent_min=np.deg2rad(7)):
         The value over which to use the von Mises-Fisher distribution.
         Underneath, a 2D Gaussian approximation is used for more numerical
         stability.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
@@ -765,6 +905,7 @@ def von_mises_in_dPsi_cdf(x, sigma, kent_min=np.deg2rad(7)):
         The CDF evaluated at the provided opening angles x.
     """
     assert len(x) == len(sigma), ("Unequal lengths:", len(x), len(sigma))
+    x, sigma = cast(dtype, x, sigma)
     x = np.atleast_1d(x)
     sigma = np.atleast_1d(sigma)
     result = []

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -1,6 +1,54 @@
 import tensorflow as tf
 
 
+def clip_logits(logits, eps=None):
+    """Clip logits to avoid numerical instabilities
+
+    Parameters
+    ----------
+    logits : tf.Tensor
+        The logits to clip.
+    eps : float, optional
+        The epsilon value to clip to, by default None.
+        If None the value will be clipped to 1e-37 for float32
+        and 1e-307 for float64.
+
+    Returns
+    -------
+    tf.Tensor
+        The clipped logits.
+    """
+    if eps is None:
+        # Up to these values, the log returns finite values
+        if logits.dtype == tf.float32:
+            eps = 1e-37
+        elif logits.dtype == tf.float64:
+            eps = 1e-307
+        else:
+            raise ValueError(f"Unknown dtype for logits: {logits.dtype}")
+    return tf.clip_by_value(logits, eps, float("inf"))
+
+
+def safe_log(logits, eps=None):
+    """Safe log operation
+
+    Parameters
+    ----------
+    logits : tf.Tensor
+        The logits to log.
+    eps : float, optional
+        The epsilon value to clip to, by default None.
+        If None the value will be clipped to 1e-37 for float32
+        and 1e-307 for float64.
+
+    Returns
+    -------
+    tf.Tensor
+        The safe log of the logits.
+    """
+    return tf.math.log(clip_logits(logits, eps=eps))
+
+
 def safe_cdf_clip(cdf_values, tol=1e-5):
     """Perform clipping of CDF values
 

--- a/test/model/multi_source/test_independent.py
+++ b/test/model/multi_source/test_independent.py
@@ -76,7 +76,10 @@ class TestIndependentMultiSource(unittest.TestCase):
             "cascade_00002_energy",
             "cascade_00002_time",
         ]
-        self.config_cascade = {"cascade_setting": 1337}
+        self.config_cascade = {
+            "cascade_setting": 1337,
+            "float_precision": "float32",
+        }
         self.base_sources = {
             "cascade": self.get_cascade_source(
                 config=self.config_cascade, data_trafo=self.data_trafo


### PR DESCRIPTION
Use float64 in crucial code parts. Changes include:

- Loss module can now fully use its own float precision
- basis functions now have an optional dtype parameter that will cast all inputs to this dtype
- Seperately set float precision for pdf and cdf evaluation in cascade and inf_track model then revert back to model float precision
-  change latent parameter scaling/boundaries back to elu function and reduce lower bound for sigma and r by one order of magnitude

Other changes in this PR:

- turn off normalization by total charge in configs
- Use reco pulses and update seed points for tracks
- Add buffer for time window calculation (Todo: add option to pass in a proper window instead of inferring it from pulse times)
- Minor speedup in minimization: jac=False now does not unnecessarily compute gradient 
- Bugfix: dt_geometry was previously incorrectly calculated for tracks