### PR TITLE
Mpe likelihood

### DIFF
--- a/configs/cascade_11param_noise_ftpv3m.yaml
+++ b/configs/cascade_11param_noise_ftpv3m.yaml
@@ -64,7 +64,7 @@ training_settings: {
 
     # Additional keywords to the loss module used for training
     'additional_loss_module_kwargs': {
-        'normalize_by_total_charge': True,
+        'normalize_by_total_charge': False,
     },
 }
 
@@ -253,18 +253,6 @@ data_iterator_settings: {
             # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30253/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
             # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30254/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
 
-            # # MESE NuGen NuE l5 Benchmark Datasets
-            # # Spice3.2.1 variable
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99900/egenerator_99900_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # Spice3.2.1 const
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99901/egenerator_99901_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # SpiceLea variable
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99902/egenerator_99902_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # SpiceLea const
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99903/egenerator_99903_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # Spice3.2.1 variable no fourier
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99911/egenerator_99911_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-
             # # FTPv3m baseline
             # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99915/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # FTPv3m SnowStorm
@@ -293,7 +281,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -307,7 +295,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -321,7 +309,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -335,7 +323,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -349,7 +337,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # define uniform priors
             'uniform_parameters': {
                 'cascade_Absorption': [0.913, 1.087],
@@ -384,7 +372,6 @@ data_trafo_settings: {
     'float_precision': 'float64',
     'norm_constant': !!float 1e-6,
     'num_batches': 5000,
-    # 'model_dir': '/cephfs/users/mhuennefeld/data/egenerator/trafo_models/trafo_model_cascade_11param_noise_ftpv3m',
     'model_dir': '/data/user/mhuennefeld/data/egenerator/trafo_models/trafo_model_cascade_11param_noise_ftpv3m',
 }
 
@@ -413,6 +400,7 @@ data_handler_settings: {
         'float_precision': 'float32',
         'add_charge_quantiles': False,
         'discard_pulses_from_excluded_doms': False,
+        'time_window_buffer': 100.,
     },
 
     # --------------------
@@ -518,6 +506,7 @@ model_settings: {
                 'charge_distribution_type': 'negative_binomial',
                 'num_latent_models': 10,
                 'float_precision': float32,
+                'float_precision_pdf_cdf': float64,
 
                 # Baseline DOM Angular acceptance
                 'use_constant_baseline_hole_ice': False,

--- a/configs/cascade_11param_noise_ftpv3m.yaml
+++ b/configs/cascade_11param_noise_ftpv3m.yaml
@@ -289,6 +289,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -302,6 +303,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -315,6 +317,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -328,6 +331,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -341,6 +345,8 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.snowstorm.SnowstormPriorLossModule',
+        'loss_module_weight': 1.0,
+
         config: {
             # the float precision to use
             'float_precision': 'float32',

--- a/configs/cascade_7param_noise_ftpv3m.yaml
+++ b/configs/cascade_7param_noise_ftpv3m.yaml
@@ -282,6 +282,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -295,6 +296,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -308,6 +310,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -321,6 +324,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use

--- a/configs/cascade_7param_noise_ftpv3m.yaml
+++ b/configs/cascade_7param_noise_ftpv3m.yaml
@@ -64,7 +64,7 @@ training_settings: {
 
     # Additional keywords to the loss module used for training
     'additional_loss_module_kwargs': {
-        'normalize_by_total_charge': True,
+        'normalize_by_total_charge': False,
     },
 }
 
@@ -181,11 +181,11 @@ data_iterator_settings: {
         'num_add_files': 12,
         'num_repetitions': 5,
         'input_data': [
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
         ],
     },
 
@@ -200,11 +200,11 @@ data_iterator_settings: {
         'num_repetitions': 1,
         'pick_random_files_forever': False,
         'input_data': [
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
         ],
     },
 
@@ -221,11 +221,11 @@ data_iterator_settings: {
         'pick_random_files_forever': True,
         'input_data': [
             # Note: The validation data is the same as the training data. Do not pay attention to validation curve!
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30250/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30251/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30252/cascades/step_3_pass2_get_all_pulses/*/*0.hdf5',
         ],
     },
 
@@ -243,31 +243,19 @@ data_iterator_settings: {
         'input_data': [
 
             # # validation data
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
-
-            # # MESE NuGen NuE l5 Benchmark Datasets
-            # # Spice3.2.1 variable
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99900/egenerator_99900_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # Spice3.2.1 const
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99901/egenerator_99901_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # SpiceLea variable
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99902/egenerator_99902_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # SpiceLea const
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99903/egenerator_99903_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
-            # # Spice3.2.1 variable no fourier
-            # # '/net/big-tank/POOL/users/mhuennefeld/data/egenerator/training_data/datasets/99911/egenerator_99911_step_3_pass2_get_pulses_py3_v4_1_0_IC86_pulses/*/00000-00999/*_0000000*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30248/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/30249/cascades/step_3_pass2_get_all_pulses/*/*00000.hdf5',
 
             # FTPv3m baseline
-            '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99915/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99915/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # # FTPv3m SnowStorm
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99916/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99916/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # # FTPv3m SnowStorm Absorption
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99917/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99917/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # # FTPv3m SnowStorm Scattering
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99918/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99918/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
             # # FTPv3m SnowStorm HoleIce
-            # '/cephfs/projects/ICECUBE/icecube/training_data/egenerator/egenerator-v1.1.0/datasets/99919/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
+            # '/data/ana/reconstruction/2018/gnn/training_data/egenerator-v1.1.0/datasets/99919/cascades/step_3_pass2_get_all_pulses/*/*.hdf5',
 
         ],
     },
@@ -286,7 +274,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -300,7 +288,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -314,7 +302,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -328,7 +316,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -357,7 +345,7 @@ data_trafo_settings: {
     'float_precision': 'float64',
     'norm_constant': !!float 1e-6,
     'num_batches': 5000,
-    'model_dir': '/cephfs/users/mhuennefeld/data/egenerator/trafo_models/trafo_model_cascade_7param_noise_ftpv3m',
+    'model_dir': '/data/user/mhuennefeld/data/egenerator/trafo_models/trafo_model_cascade_7param_noise_ftpv3m',
 }
 
 #----------------------
@@ -385,6 +373,7 @@ data_handler_settings: {
         'float_precision': 'float32',
         'add_charge_quantiles': False,
         'discard_pulses_from_excluded_doms': False,
+        'time_window_buffer': 100.,
     },
 
     # --------------------
@@ -492,6 +481,7 @@ model_settings: {
                 'charge_distribution_type': 'negative_binomial',
                 'num_latent_models': 10,
                 'float_precision': float32,
+                'float_precision_pdf_cdf': float64,
 
                 # Baseline DOM Angular acceptance
                 'use_constant_baseline_hole_ice': True,

--- a/configs/track_sphere_6param_ftpv3m.yaml
+++ b/configs/track_sphere_6param_ftpv3m.yaml
@@ -64,7 +64,7 @@ training_settings: {
 
     # Additional keywords to the loss module used for training
     'additional_loss_module_kwargs': {
-        'normalize_by_total_charge': True,
+        'normalize_by_total_charge': False,
     },
 }
 
@@ -274,7 +274,7 @@ loss_module_settings: [
 
         config: {
             # the float precision to use
-            'float_precision': 'float32',
+            'float_precision': 'float64',
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
@@ -288,7 +288,7 @@ loss_module_settings: [
 
     #     config: {
     #         # the float precision to use
-    #         'float_precision': 'float32',
+    #         'float_precision': 'float64',
     #         # Add normalization terms to llh if True
     #         'add_normalization_term': True,
     #         # choose the loss function to use
@@ -302,7 +302,7 @@ loss_module_settings: [
 
     #     config: {
     #         # the float precision to use
-    #         'float_precision': 'float32',
+    #         'float_precision': 'float64',
     #         # Add normalization terms to llh if True
     #         'add_normalization_term': True,
     #         # choose the loss function to use
@@ -316,7 +316,7 @@ loss_module_settings: [
 
     #     config: {
     #         # the float precision to use
-    #         'float_precision': 'float32',
+    #         'float_precision': 'float64',
     #         # Add normalization terms to llh if True
     #         'add_normalization_term': True,
     #         # choose the loss function to use
@@ -330,7 +330,7 @@ loss_module_settings: [
 
     #     config: {
     #         # the float precision to use
-    #         'float_precision': 'float32',
+    #         'float_precision': 'float64',
     #         # Add normalization terms to llh if True
     #         'add_normalization_term': True,
     #         # choose the loss function to use
@@ -380,13 +380,14 @@ data_handler_settings: {
 
     # settings for the data module
     'data_settings':{
-        'pulse_key': 'MCPulses',
+        'pulse_key': 'InIceDSTPulses_masked_doms_only',
         'event_id_key': 'LabelsMCTrackSphere',
         'dom_exclusions_key': BadDomsList,
         'time_exclusions_key': ,
         'float_precision': 'float32',
         'add_charge_quantiles': False,
         'discard_pulses_from_excluded_doms': False,
+        'time_window_buffer': 100.,
     },
 
     # --------------------
@@ -488,7 +489,7 @@ model_settings: {
                 'keep_prob':,
                 'sphere_radius': 750.,
                 'add_anisotropy_angle': True,
-                'add_dom_angular_acceptance': False,
+                'add_dom_angular_acceptance': True,
                 'add_dom_coordinates': False,
                 'num_local_vars': 0,
                 'scale_charge': True,
@@ -500,6 +501,7 @@ model_settings: {
                 'charge_distribution_type': 'negative_binomial',
                 'num_latent_models': 10,
                 'float_precision': float32,
+                'float_precision_pdf_cdf': float64,
 
                 # Baseline DOM Angular acceptance
                 'use_constant_baseline_hole_ice': True,
@@ -508,7 +510,7 @@ model_settings: {
 
                 # First convolutions
                 'filter_size_list' : [[1, 1], [1, 1], [1, 1], [1, 1], [1, 1], [1, 1]],
-                'num_filters_list' : [25, 100, 100, 100, 100, 42],
+                'num_filters_list' : [50, 200, 200, 200, 200, 42],
                 'method_list' : ['locally_connected',
                                  'convolution', 'convolution', 'convolution',
                                  'convolution', 'convolution',

--- a/configs/track_sphere_6param_ftpv3m.yaml
+++ b/configs/track_sphere_6param_ftpv3m.yaml
@@ -278,51 +278,65 @@ loss_module_settings: [
             # Add normalization terms to llh if True
             'add_normalization_term': True,
             # choose the loss function to use
-            'loss_function_name': 'unbinned_pulse_time_llh',
+            'loss_function_name': 'unbinned_pulse_time_mpe_llh',
         },
     },
-    {
-        # The loss module class to use
-        'loss_module': 'egenerator.loss.default.DefaultLossModule',
-        'loss_module_weight': 1.0,
+    # {
+    #     # The loss module class to use
+    #     'loss_module': 'egenerator.loss.default.DefaultLossModule',
+    #     'loss_module_weight': 1.0,
 
-        config: {
-            # the float precision to use
-            'float_precision': 'float32',
-            # Add normalization terms to llh if True
-            'add_normalization_term': True,
-            # choose the loss function to use
-            'loss_function_name': 'normalized_dom_charge_pdf',
-        },
-    },
-    {
-        # The loss module class to use
-        'loss_module': 'egenerator.loss.default.DefaultLossModule',
-        'loss_module_weight': 1.0,
+    #     config: {
+    #         # the float precision to use
+    #         'float_precision': 'float32',
+    #         # Add normalization terms to llh if True
+    #         'add_normalization_term': True,
+    #         # choose the loss function to use
+    #         'loss_function_name': 'unbinned_pulse_time_llh',
+    #     },
+    # },
+    # {
+    #     # The loss module class to use
+    #     'loss_module': 'egenerator.loss.default.DefaultLossModule',
+    #     'loss_module_weight': 1.0,
 
-        config: {
-            # the float precision to use
-            'float_precision': 'float32',
-            # Add normalization terms to llh if True
-            'add_normalization_term': True,
-            # choose the loss function to use
-            'loss_function_name': 'negative_binomial_charge_pdf',
-        },
-    },
-    {
-        # The loss module class to use
-        'loss_module': 'egenerator.loss.default.DefaultLossModule',
-        'loss_module_weight': 1.0,
+    #     config: {
+    #         # the float precision to use
+    #         'float_precision': 'float32',
+    #         # Add normalization terms to llh if True
+    #         'add_normalization_term': True,
+    #         # choose the loss function to use
+    #         'loss_function_name': 'normalized_dom_charge_pdf',
+    #     },
+    # },
+    # {
+    #     # The loss module class to use
+    #     'loss_module': 'egenerator.loss.default.DefaultLossModule',
+    #     'loss_module_weight': 1.0,
 
-        config: {
-            # the float precision to use
-            'float_precision': 'float32',
-            # Add normalization terms to llh if True
-            'add_normalization_term': True,
-            # choose the loss function to use
-            'loss_function_name': 'negative_binomial_event_charge_pdf',
-        },
-    },
+    #     config: {
+    #         # the float precision to use
+    #         'float_precision': 'float32',
+    #         # Add normalization terms to llh if True
+    #         'add_normalization_term': True,
+    #         # choose the loss function to use
+    #         'loss_function_name': 'negative_binomial_charge_pdf',
+    #     },
+    # },
+    # {
+    #     # The loss module class to use
+    #     'loss_module': 'egenerator.loss.default.DefaultLossModule',
+    #     'loss_module_weight': 1.0,
+
+    #     config: {
+    #         # the float precision to use
+    #         'float_precision': 'float32',
+    #         # Add normalization terms to llh if True
+    #         'add_normalization_term': True,
+    #         # choose the loss function to use
+    #         'loss_function_name': 'negative_binomial_event_charge_pdf',
+    #     },
+    # },
 ]
 
 #---------------------------

--- a/configs/track_sphere_6param_ftpv3m.yaml
+++ b/configs/track_sphere_6param_ftpv3m.yaml
@@ -270,6 +270,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -283,6 +284,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -296,6 +298,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use
@@ -309,6 +312,7 @@ loss_module_settings: [
     {
         # The loss module class to use
         'loss_module': 'egenerator.loss.default.DefaultLossModule',
+        'loss_module_weight': 1.0,
 
         config: {
             # the float precision to use

--- a/egenerator/__about__.py
+++ b/egenerator/__about__.py
@@ -86,5 +86,17 @@ __version_compatibility__ = {
             ),
             "type": "global",
         },
+        {
+            "Description": (
+                "The x_pulses_ids now also includes the pulse number at "
+                "the given DOM. This allows for easy selection of the "
+                "first pulses at a DOM, for instance. "
+                "A result of this change is that the tensor changed "
+                "its shape from [n_pulses, 3] to [n_pulses, 4]. This "
+                "breaks backwards compatibility and may also require "
+                "updates in dependen user code."
+            ),
+            "type": "global",
+        },
     ],
 }

--- a/egenerator/addons/sphere_inf_track/__init__.py
+++ b/egenerator/addons/sphere_inf_track/__init__.py
@@ -1,0 +1,5 @@
+from .sphere_inf_track_seeder import SphereInfTrackSeedConverter
+
+__all__ = [
+    "SphereInfTrackSeedConverter",
+]

--- a/egenerator/addons/sphere_inf_track/sphere_inf_track_seeder.py
+++ b/egenerator/addons/sphere_inf_track/sphere_inf_track_seeder.py
@@ -1,6 +1,6 @@
 from icecube import icetray
 
-from ic3_labels.labels.modules.muon_track_labels import (
+from ic3_labels.labels.modules.event_generator.muon_track_labels import (
     get_sphere_inf_track_geometry_values,
 )
 

--- a/egenerator/addons/sphere_inf_track/sphere_inf_track_seeder.py
+++ b/egenerator/addons/sphere_inf_track/sphere_inf_track_seeder.py
@@ -1,3 +1,4 @@
+import math
 from icecube import icetray
 
 from ic3_labels.labels.modules.event_generator.muon_track_labels import (
@@ -24,12 +25,18 @@ class SphereInfTrackSeedConverter(icetray.I3ConditionalModule):
             "The radius of the sphere around IceCube [in meters].",
             750,
         )
+        self.AddParameter(
+            "replacement_values",
+            "Replacement values for non-finite values.",
+            {"entry_energy": 10000.0},
+        )
 
     def Configure(self):
         """Configure"""
         self._seed_key = self.GetParameter("seed_key")
         self._output_key = self.GetParameter("output_key")
         self._sphere_radius = self.GetParameter("sphere_radius")
+        self._replacement_values = self.GetParameter("replacement_values")
 
         if self._output_key is None:
             self._output_key = self._seed_key + "_SphereInfTrackSeed"
@@ -54,6 +61,11 @@ class SphereInfTrackSeedConverter(icetray.I3ConditionalModule):
 
         # add energy
         geometry_values["entry_energy"] = track.energy
+
+        # replace non-finite values
+        for key, value in self._replacement_values.items():
+            if not math.isfinite(geometry_values[key]):
+                geometry_values[key] = value
 
         frame[self._output_key] = geometry_values
         self.PushFrame(frame)

--- a/egenerator/addons/sphere_inf_track/sphere_inf_track_seeder.py
+++ b/egenerator/addons/sphere_inf_track/sphere_inf_track_seeder.py
@@ -1,0 +1,59 @@
+from icecube import icetray
+
+from ic3_labels.labels.modules.muon_track_labels import (
+    get_sphere_inf_track_geometry_values,
+)
+
+
+class SphereInfTrackSeedConverter(icetray.I3ConditionalModule):
+    """Class to convert a I3Particle to a seed for the sphere inf track model"""
+
+    def __init__(self, context):
+        icetray.I3ConditionalModule.__init__(self, context)
+        self.AddParameter(
+            "seed_key",
+            "The I3Particle which will be used as the seed.",
+        )
+        self.AddParameter(
+            "output_key",
+            "The output frame key to which the clusters will be written.",
+            None,
+        )
+        self.AddParameter(
+            "SphereRadius",
+            "The radius of the sphere around IceCube [in meters].",
+            750,
+        )
+
+    def Configure(self):
+        """Configure"""
+        self._seed_key = self.GetParameter("seed_key")
+        self._output_key = self.GetParameter("output_key")
+        self._sphere_radius = self.GetParameter("SphereRadius")
+
+        if self._output_key is None:
+            self._output_key = self._seed_key + "_SphereInfTrackSeed"
+
+    def Physics(self, frame):
+        """Convert I3Particle to a seed for the sphere inf track model
+
+        Parameters
+        ----------
+        frame : I3Frame
+            The current I3frame.
+        """
+
+        # get track
+        track = frame[self._seed_key]
+
+        # get geometry values
+        geometry_values, _, _ = get_sphere_inf_track_geometry_values(
+            muon=track,
+            sphere_radius=self._sphere_radius,
+        )
+
+        # add energy
+        geometry_values["entry_energy"] = track.energy
+
+        frame[self._output_key] = geometry_values
+        self.PushFrame(frame)

--- a/egenerator/addons/sphere_inf_track/sphere_inf_track_seeder.py
+++ b/egenerator/addons/sphere_inf_track/sphere_inf_track_seeder.py
@@ -20,7 +20,7 @@ class SphereInfTrackSeedConverter(icetray.I3ConditionalModule):
             None,
         )
         self.AddParameter(
-            "SphereRadius",
+            "sphere_radius",
             "The radius of the sphere around IceCube [in meters].",
             750,
         )
@@ -29,7 +29,7 @@ class SphereInfTrackSeedConverter(icetray.I3ConditionalModule):
         """Configure"""
         self._seed_key = self.GetParameter("seed_key")
         self._output_key = self.GetParameter("output_key")
-        self._sphere_radius = self.GetParameter("SphereRadius")
+        self._sphere_radius = self.GetParameter("sphere_radius")
 
         if self._output_key is None:
             self._output_key = self._seed_key + "_SphereInfTrackSeed"

--- a/egenerator/data/modules/data/pulse_data.py
+++ b/egenerator/data/modules/data/pulse_data.py
@@ -44,6 +44,7 @@ class PulseDataModule(BaseComponent):
         float_precision,
         add_charge_quantiles,
         discard_pulses_from_excluded_doms,
+        time_window_buffer,
     ):
         """Configure Module Class
         This is an abstract method and must be implemented by derived class.
@@ -75,6 +76,11 @@ class PulseDataModule(BaseComponent):
         discard_pulses_from_excluded_doms : bool, optional
             If True, pulses on excluded DOMs are discarded. The pulses are
             discarded after the charge at the DOM is collected.
+        time_window_buffer : float
+            The additional buffer time to add to the time window
+            on either side. The time window is defined as
+            [min(pulse_times) - buffer, max(pulse_times) + buffer].
+
 
         Returns
         -------
@@ -119,6 +125,9 @@ class PulseDataModule(BaseComponent):
         if not isinstance(pulse_key, str):
             msg = "Pulse key type: {!r} != str"
             raise TypeError(msg.format(type(pulse_key)))
+
+        if time_window_buffer < 0:
+            raise ValueError("Time window buffer must be >= 0")
 
         time_exclusions_exist = time_exclusions_key is not None
         dom_exclusions_exist = dom_exclusions_key is not None
@@ -214,6 +223,7 @@ class PulseDataModule(BaseComponent):
                 config_data=config_data,
                 float_precision=float_precision,
                 add_charge_quantiles=add_charge_quantiles,
+                time_window_buffer=time_window_buffer,
             ),
             mutable_settings=dict(
                 pulse_key=pulse_key,
@@ -391,6 +401,20 @@ class PulseDataModule(BaseComponent):
                 x_time_window[index, 1] = row.time
             if row.time < x_time_window[index, 0]:
                 x_time_window[index, 0] = row.time
+
+        # increase time window by buffer
+        buffer = self.configuration.config["time_window_buffer"]
+
+        # non-finite values should only happen if there are no pulses
+        mask_infinite1 = ~np.isfinite(x_time_window[:, 0])
+        mask_infinite2 = ~np.isfinite(x_time_window[:, 1])
+        assert np.all(mask_infinite1 == mask_infinite2)
+        x_time_window[mask_infinite1, 0] = 0
+        x_time_window[mask_infinite2, 1] = 0
+
+        if buffer > 0:
+            x_time_window[:, 0] -= buffer
+            x_time_window[:, 1] += buffer
 
         # convert cumulative charge to fraction of total charge, e.g. quantile
         if add_charge_quantiles:
@@ -623,6 +647,20 @@ class PulseDataModule(BaseComponent):
                     x_time_window[index, 1] = pulse.time
                 if pulse.time < x_time_window[index, 0]:
                     x_time_window[index, 0] = pulse.time
+
+        # increase time window by buffer
+        buffer = self.configuration.config["time_window_buffer"]
+
+        # non-finite values should only happen if there are no pulses
+        mask_infinite1 = ~np.isfinite(x_time_window[:, 0])
+        mask_infinite2 = ~np.isfinite(x_time_window[:, 1])
+        assert np.all(mask_infinite1 == mask_infinite2)
+        x_time_window[mask_infinite1, 0] = 0
+        x_time_window[mask_infinite2, 1] = 0
+
+        if buffer > 0:
+            x_time_window[:, 0] -= buffer
+            x_time_window[:, 1] += buffer
 
         x_pulses = np.array(x_pulses, dtype=self.data["np_float_precision"])
         x_pulses_ids = np.array(x_pulses_ids, dtype=np.int32)

--- a/egenerator/loss/default.py
+++ b/egenerator/loss/default.py
@@ -578,9 +578,9 @@ class DefaultLossModule(BaseComponent):
         # Shape: [n_pulses_first]
         eps = 1e-7
         mpe_log_llh = (
-            tf.math.log(dom_charges_true_pulses)
+            tf.math.log(dom_charges_true_pulses + eps)
             + pulse_charge_first * tf.math.log(pulse_pdf_value_first + eps)
-            + (dom_charges_true_pulses - pulse_charge_first)
+            + (dom_charges_true_pulses - pulse_charge_first + eps)
             * tf.math.log(1 - pulse_cdf_value_first + eps)
         )
         time_loss = -mpe_log_llh

--- a/egenerator/loss/multi_loss.py
+++ b/egenerator/loss/multi_loss.py
@@ -24,13 +24,17 @@ class MultiLossModule(BaseComponent):
         self._logger = logger or logging.getLogger(__name__)
         super(MultiLossModule, self).__init__(logger=self._logger)
 
-    def _configure(self, loss_modules):
+    def _configure(self, loss_modules, loss_modules_weights):
         """Configure the MultiLossModule component instance.
 
         Parameters
         ----------
         loss_modules : list of loss modules
             A list of loss module components.
+        loss_modules_weights : list of float
+            A list of weights for the loss modules.
+            The loss of each loss module will be multiplied by the
+            corresponding weight.
 
         Returns
         -------
@@ -65,16 +69,22 @@ class MultiLossModule(BaseComponent):
         """
 
         dependent_sub_components = {}
+        weight_dict = {}
         for i, module in enumerate(loss_modules):
-            dependent_sub_components["loss_modules_{:04d}".format(i)] = module
+            dependent_sub_components[f"loss_modules_{i:04d}"] = module
+            weight_dict[f"loss_modules_{i:04d}"] = loss_modules_weights[i]
 
         # create configuration object
         configuration = Configuration(
             class_string=misc.get_full_class_string_of_object(self),
             settings=dict(),
+            mutable_settings=dict(loss_modules_weights=loss_modules_weights),
         )
+        data = {
+            "weight_dict": weight_dict,
+        }
 
-        return configuration, {}, dependent_sub_components
+        return configuration, data, dependent_sub_components
 
     def get_loss(
         self,
@@ -149,6 +159,7 @@ class MultiLossModule(BaseComponent):
         loss_terms = []
         loss = None
         for key in sorted(self.sub_components.keys()):
+            weight_i = self.data["weight_dict"][key]
             loss_module = self.sub_components[key]
             loss_i = loss_module.get_loss(
                 data_batch_dict=data_batch_dict,
@@ -164,7 +175,7 @@ class MultiLossModule(BaseComponent):
                 if loss is None:
                     loss = loss_i
                 else:
-                    loss += loss_i
+                    loss += loss_i * weight_i
             else:
                 if sort_loss_terms:
                     assert len(loss_i) == 3, (loss_module, loss_i)
@@ -173,8 +184,11 @@ class MultiLossModule(BaseComponent):
                         loss_terms = loss_i
                     else:
                         for term_index in range(3):
-                            loss_terms[term_index] += loss_i[term_index]
+                            loss_terms[term_index] += (
+                                loss_i[term_index] * weight_i
+                            )
                 else:
+                    loss_i = [loss_i_i * weight_i for loss_i_i in loss_i]
                     loss_terms.extend(loss_i)
 
         if reduce_to_scalar:

--- a/egenerator/loss/snowstorm.py
+++ b/egenerator/loss/snowstorm.py
@@ -195,6 +195,10 @@ class SnowstormPriorLossModule(BaseComponent):
         normalization = np.exp(exp_factor)
 
         def loss_excess(scaled_excess):
+            scaled_excess = tf.cast(
+                scaled_excess,
+                self.configuration.config["config"]["float_precision"],
+            )
             return tf.exp((scaled_excess + 1) * exp_factor) - normalization
 
         loss = tf.where(
@@ -314,6 +318,7 @@ class SnowstormPriorLossModule(BaseComponent):
                 fourier_values,
                 mu=tf.zeros_like(fourier_sigmas),
                 sigma=fourier_sigmas,
+                dtype=self.configuration.config["config"]["float_precision"],
             )
 
             # we will use the negative log likelihood as loss

--- a/egenerator/manager/reconstruction/modules/fit_quality.py
+++ b/egenerator/manager/reconstruction/modules/fit_quality.py
@@ -682,7 +682,10 @@ class GoodnessOfFit:
                         np.cumsum(pulse_charges) / np.sum(pulse_charges)
                     )
                 pulses = np.stack(pulse_elements, axis=1)
-                pulses_ids = np.tile((0, string, om), reps=[num_pe, 1])
+                pulses_ids = np.tile((0, string, om, 0), reps=[num_pe, 1])
+
+                # set pulse number
+                pulses_ids[:, 3] = np.arange(num_pe)
 
                 x_pulses.append(pulses)
                 x_pulses_ids.append(pulses_ids)

--- a/egenerator/manager/reconstruction/modules/reconstruction.py
+++ b/egenerator/manager/reconstruction/modules/reconstruction.py
@@ -166,11 +166,17 @@ class Reconstruction:
         # choose reconstruction method depending on the optimizer interface
         if reco_optimizer_interface.lower() == "scipy":
 
+            # choose function according to jac (default: True)
+            scipy_loss_function = loss_and_gradients_function
+            if "jac" in scipy_optimizer_settings:
+                if not scipy_optimizer_settings["jac"]:
+                    scipy_loss_function = self.parameter_loss_function
+
             def reconstruction_method(data_batch, seed_tensor):
                 return manager.reconstruct_events(
                     data_batch,
                     loss_module,
-                    loss_and_gradients_function=loss_and_gradients_function,
+                    loss_and_gradients_function=scipy_loss_function,
                     fit_parameter_list=fit_parameter_list,
                     minimize_in_trafo_space=minimize_in_trafo_space,
                     seed=seed_tensor,

--- a/egenerator/manager/source.py
+++ b/egenerator/manager/source.py
@@ -632,7 +632,7 @@ class SourceManager(BaseModelManager):
         def model_tensors_function(
             parameters,
             x_pulses=tf.ones([1, x_pulses_shape[1]], dtype=pulse_dtype),
-            x_pulses_ids=tf.convert_to_tensor([[0, 0, 0]]),
+            x_pulses_ids=tf.convert_to_tensor([[0, 0, 0, 0]]),
             x_dom_exclusions=tf.ones([0, 86, 60, 1], dtype=tf.bool),
             x_dom_charge=tf.ones([0, 86, 60, 1], dtype=param_dtype),
             x_time_window=tf.convert_to_tensor([[9000, 9001]], dtype=tw_dtype),
@@ -654,8 +654,9 @@ class SourceManager(BaseModelManager):
                 Shape: [n_pulses, 2]
             x_pulses_ids : tf.Tensor, optional
                 The pulse ids. These identify to which event and string and
-                DOM each pulse belongs to: [[batch_id, string-1, DOM-1]]
-                Shape: [n_pulses, 3]
+                DOM each pulse belongs to:
+                    [[batch_id, string-1, DOM-1, pulse_number]]
+                Shape: [n_pulses, 4]
             x_dom_exclusions : tf.Tensor, optional
                 A boolean tensor which denotes which DOM is excluded.
                 Shape: [n_events, 86, 60, 1]

--- a/egenerator/model/multi_source/base.py
+++ b/egenerator/model/multi_source/base.py
@@ -459,7 +459,7 @@ class MultiSource(Source):
         # normalize time exclusion sum: divide by total charge at DOM
         if time_exclusions_exist:
             dom_cdf_exclusion_sum = tf_helpers.safe_cdf_clip(
-                dom_cdf_exclusion_sum / dom_charges
+                dom_cdf_exclusion_sum / (dom_charges + self.epsilon)
             )
 
             result_tensors["dom_cdf_exclusion_sum"] = dom_cdf_exclusion_sum

--- a/egenerator/model/multi_source/base.py
+++ b/egenerator/model/multi_source/base.py
@@ -400,9 +400,9 @@ class MultiSource(Source):
                 pulse_cdf_exclusion = tf.gather_nd(
                     tf.squeeze(dom_cdf_exclusion_sum_i, axis=-1), pulses_ids
                 )
-                pulse_pdf_i *= 1.0 - pulse_cdf_exclusion + 1e-3
+                pulse_pdf_i *= 1.0 - pulse_cdf_exclusion + self.epsilon
                 if all_models_have_cdf_values:
-                    pulse_cdf_i *= 1.0 - pulse_cdf_exclusion + 1e-3
+                    pulse_cdf_i *= 1.0 - pulse_cdf_exclusion + self.epsilon
 
             # accumulate charge
             # (assumes that sources are linear and independent)
@@ -443,9 +443,9 @@ class MultiSource(Source):
             tf.squeeze(dom_charges, axis=3), pulses_ids
         )
 
-        pulse_pdf /= pulse_weight_total + 1e-6
+        pulse_pdf /= pulse_weight_total + self.epsilon
         if all_models_have_cdf_values:
-            pulse_cdf /= pulse_weight_total + 1e-6
+            pulse_cdf /= pulse_weight_total + self.epsilon
 
         result_tensors = {
             "dom_charges": dom_charges,
@@ -468,10 +468,14 @@ class MultiSource(Source):
             pulse_cdf_exclusion = tf.gather_nd(
                 tf.squeeze(dom_cdf_exclusion_sum, axis=-1), pulses_ids
             )
-            result_tensors["pulse_pdf"] /= 1.0 - pulse_cdf_exclusion + 1e-3
+            result_tensors["pulse_pdf"] /= (
+                1.0 - pulse_cdf_exclusion + self.epsilon
+            )
 
             if all_models_have_cdf_values:
-                result_tensors["pulse_cdf"] /= 1.0 - pulse_cdf_exclusion + 1e-3
+                result_tensors["pulse_cdf"] /= (
+                    1.0 - pulse_cdf_exclusion + self.epsilon
+                )
 
         # ensure proper CDF ranges
         if "pulse_cdf" in result_tensors:

--- a/egenerator/model/multi_source/base.py
+++ b/egenerator/model/multi_source/base.py
@@ -272,9 +272,9 @@ class MultiSource(Source):
                 The input pulses (charge, time) of all events in a batch.
                 Shape: [-1, 2]
             pulses_ids : tf.Tensor
-                The pulse indices (batch_index, string, dom) of all pulses in
-                the batch of events.
-                Shape: [-1, 3]
+                The pulse indices (batch_index, string, dom, pulse_number)
+                of all pulses in the batch of events.
+                Shape: [-1, 4]
         is_training : bool, optional
             Indicates whether currently in training or inference mode.
             Must be provided if batch normalisation is used.
@@ -299,11 +299,17 @@ class MultiSource(Source):
                 'pulse_pdf': The likelihood evaluated for each pulse
                              Shape: [-1]
 
+            Optional:
+
+                'pulse_cdf': The cumulative likelihood evaluated
+                             for each pulse
+                             Shape: [-1]
+
         """
         self.assert_configured(True)
 
         parameters = data_batch_dict[parameter_tensor_name]
-        pulses_ids = data_batch_dict["x_pulses_ids"]
+        pulses_ids = data_batch_dict["x_pulses_ids"][:, :3]
 
         parameters = self.add_parameter_indexing(parameters)
         source_parameters = self.get_source_parameters(parameters)
@@ -333,7 +339,9 @@ class MultiSource(Source):
         dom_charges = None
         dom_charges_variance = None
         dom_cdf_exclusion_sum = None
+        all_models_have_cdf_values = True
         pulse_pdf = None
+        pulse_cdf = None
         nested_results = {}
         for name, base in sorted(self._untracked_data["sources"].items()):
 
@@ -358,6 +366,10 @@ class MultiSource(Source):
             dom_charges_i = result_tensors_i["dom_charges"]
             dom_charges_variance_i = result_tensors_i["dom_charges_variance"]
             pulse_pdf_i = result_tensors_i["pulse_pdf"]
+            if "pulse_cdf" in result_tensors_i:
+                pulse_cdf_i = result_tensors_i["pulse_cdf"]
+            else:
+                all_models_have_cdf_values = False
 
             if dom_charges_i.shape[1:] != [86, 60, 1]:
                 msg = "DOM charges of source {!r} ({!r}) have an unexpected "
@@ -388,6 +400,8 @@ class MultiSource(Source):
                     tf.squeeze(dom_cdf_exclusion_sum_i, axis=-1), pulses_ids
                 )
                 pulse_pdf_i *= 1.0 - pulse_cdf_exclusion + 1e-3
+                if all_models_have_cdf_values:
+                    pulse_cdf_i *= 1.0 - pulse_cdf_exclusion + 1e-3
 
             # accumulate charge
             # (assumes that sources are linear and independent)
@@ -417,12 +431,20 @@ class MultiSource(Source):
             else:
                 pulse_pdf += pulse_pdf_i * pulse_weight_i
 
+            if all_models_have_cdf_values:
+                if pulse_cdf is None:
+                    pulse_cdf = pulse_cdf_i * pulse_weight_i
+                else:
+                    pulse_cdf += pulse_cdf_i * pulse_weight_i
+
         # normalize pulse_pdf values: divide by total charge at DOM
         pulse_weight_total = tf.gather_nd(
             tf.squeeze(dom_charges, axis=3), pulses_ids
         )
 
         pulse_pdf /= pulse_weight_total + 1e-6
+        if all_models_have_cdf_values:
+            pulse_cdf /= pulse_weight_total + 1e-6
 
         result_tensors = {
             "dom_charges": dom_charges,
@@ -430,6 +452,8 @@ class MultiSource(Source):
             "pulse_pdf": pulse_pdf,
             "nested_results": nested_results,
         }
+        if all_models_have_cdf_values:
+            result_tensors["pulse_cdf"] = pulse_cdf
 
         # normalize time exclusion sum: divide by total charge at DOM
         if time_exclusions_exist:
@@ -443,307 +467,8 @@ class MultiSource(Source):
             )
             result_tensors["pulse_pdf"] /= 1.0 - pulse_cdf_exclusion + 1e-3
 
-        return result_tensors
-
-    @tf.function
-    def get_tensors_batched(
-        self,
-        data_batch_dict,
-        is_training,
-        parameter_tensor_name="x_parameters",
-    ):
-        """Get tensors computed from input parameters and pulses.
-
-        Parameters are the hypothesis tensor of the source with
-        shape [-1, n_params]. The get_tensors method must compute all tensors
-        that are to be used in later steps. It returns these as a dictionary
-        of output tensors.
-
-        Note: this calculates the same as `get_tensors`, but models are first
-        lumped to together and then run through the base models as a batch.
-        In the current implementation, this requires the duplication of the
-        input data which might lead to significantly higher memory usage.
-
-        Note: this implementation does not support output of nested result
-        tensors, which is required for the `pdf` and `sample_pulses` methods.
-        If these are needed, use `get_tensors` instead.
-
-        Parameters
-        ----------
-        data_batch_dict : dict of tf.Tensor
-            parameters : tf.Tensor
-                A tensor which describes the input parameters of the source.
-                This fully defines the source hypothesis. The tensor is of
-                shape [-1, n_params] and the last dimension must match the
-                order of the parameter names (self.parameter_names),
-            pulses : tf.Tensor
-                The input pulses (charge, time) of all events in a batch.
-                Shape: [-1, 2]
-            pulses_ids : tf.Tensor
-                The pulse indices (batch_index, string, dom) of all pulses in
-                the batch of events.
-                Shape: [-1, 3]
-        is_training : bool, optional
-            Indicates whether currently in training or inference mode.
-            Must be provided if batch normalisation is used.
-            True: in training mode
-            False: inference mode.
-        parameter_tensor_name : str, optional
-            The name of the parameter tensor to use. Default: 'x_parameters'
-
-        Raises
-        ------
-        ValueError
-            Description
-
-        Returns
-        -------
-        dict of tf.Tensor
-            A dictionary of output tensors.
-            This  dictionary must at least contain:
-
-                'dom_charges': the predicted charge at each DOM
-                               Shape: [-1, 86, 60, 1]
-                'pulse_pdf': The likelihood evaluated for each pulse
-                             Shape: [-1]
-
-        """
-        self.assert_configured(True)
-
-        parameters = data_batch_dict[parameter_tensor_name]
-        pulses = data_batch_dict["x_pulses"]
-        pulses_ids = data_batch_dict["x_pulses_ids"]
-        source_names = sorted(self._untracked_data["sources"].keys())
-        n_events = tf.shape(data_batch_dict["x_dom_charge"])[0]
-
-        parameters = self.add_parameter_indexing(parameters)
-        source_parameters = self.get_source_parameters(parameters)
-
-        # check if time exclusions exist
-        tensors = self.data_trafo.data["tensors"]
-        if (
-            "x_time_exclusions" in tensors.names
-            and tensors.list[tensors.get_index("x_time_exclusions")].exists
-        ):
-            time_exclusions_exist = True
-            tws = data_batch_dict["x_time_exclusions"]
-            tws_ids = data_batch_dict["x_time_exclusions_ids"]
-        else:
-            time_exclusions_exist = False
-
-        # -----------------------------------------------
-        # get concrete functions of base sources.
-        # That way tracing only needs to be applied once.
-        # -----------------------------------------------
-        input_signature = None
-
-        concrete_tensor_funcs = {}
-        for base in set(self._untracked_data["sources"].values()):
-            base_source = self.sub_components[base]
-
-            @tf.function(input_signature=input_signature)
-            def concrete_function(data_batch_dict_i):
-                print("Tracing multi-source base: {}".format(base))
-                return base_source.get_tensors(
-                    data_batch_dict_i,
-                    is_training=is_training,
-                    parameter_tensor_name="x_parameters",
-                )
-
-            concrete_tensor_funcs[base] = concrete_function
-
-        # --------------------------------------
-        # Get input tensors for each base source
-        # --------------------------------------
-        base_parameter_tensors = {}
-        base_parameter_count = {}
-        for base in set(self._untracked_data["sources"].values()):
-            base_parameter_tensors[base] = []
-            base_parameter_count[base] = 0
-
-        for source_name in source_names:
-
-            # get input parameters for Source i
-            base = self._untracked_data["sources"][source_name]
-            base_parameter_tensors[base].append(source_parameters[source_name])
-            base_parameter_count[base] += 1
-            print(
-                base,
-                base_parameter_count[base],
-                source_parameters[source_name],
-            )
-
-        # concatenate tensors: [n_sources * n_batch, ...]
-        for base in set(self._untracked_data["sources"].values()):
-            base_parameter_tensors[base] = tf.concat(
-                base_parameter_tensors[base],
-                axis=0,
-            )
-        # --------------------------------------
-
-        dom_charges = None
-        dom_charges_variance = None
-        dom_cdf_exclusion_sum = None
-        pulse_pdf = None
-        for name, base in set(self._untracked_data["sources"].items()):
-
-            # get the base source
-            n_sources = base_parameter_count[base]
-            sub_component = self.sub_components[base]
-
-            # get input parameters for base source i
-            parameters_i = base_parameter_tensors[base]
-            parameters_i = sub_component.add_parameter_indexing(parameters_i)
-
-            # create pulses, time windows and ids for each added
-            # source batch dimension
-            if n_sources > 1:
-                x_pulses_ids_i = []
-                if time_exclusions_exist:
-                    x_time_exclusions_ids_i = []
-
-                for i in range(n_sources):
-                    offset = [[i * n_events, 0, 0]]
-                    x_pulses_ids_i.append(pulses_ids + offset)
-                    if time_exclusions_exist:
-                        x_time_exclusions_ids_i.append(tws_ids + offset)
-
-                # put tensors together
-                x_pulses_i = tf.tile(pulses, multiples=[n_sources, 1])
-                x_pulses_ids_i = tf.concat(x_pulses_ids_i, axis=0)
-                if time_exclusions_exist:
-                    x_time_exclusions_i = tf.tile(
-                        tws, multiples=[n_sources, 1]
-                    )
-                    x_time_exclusions_ids_i = tf.concat(
-                        x_time_exclusions_ids_i, axis=0
-                    )
-
-                # Get expected DOM charge and Likelihood evaluations for base i
-                data_batch_dict_i = {
-                    "x_parameters": parameters_i,
-                    "x_pulses": x_pulses_i,
-                    "x_pulses_ids": x_pulses_ids_i,
-                }
-                if time_exclusions_exist:
-                    data_batch_dict_i.update(
-                        {
-                            "x_time_exclusions": x_time_exclusions_i,
-                            "x_time_exclusions_ids": x_time_exclusions_ids_i,
-                        }
-                    )
-            else:
-                data_batch_dict_i = {"x_parameters": parameters_i}
-                x_pulses_ids_i = pulses_ids
-
-            set_keys = data_batch_dict_i.keys()
-
-            for key, values in data_batch_dict.items():
-                if key not in set_keys:
-                    data_batch_dict_i[key] = values
-
-            result_tensors_i = concrete_tensor_funcs[base](data_batch_dict_i)
-
-            # shape: [n_sources * n_batch, ...]
-            dom_charges_i = result_tensors_i["dom_charges"]
-            dom_charges_variance_i = result_tensors_i["dom_charges_variance"]
-            pulse_pdf_i = result_tensors_i["pulse_pdf"]
-
-            if dom_charges_i.shape[1:] != [86, 60, 1]:
-                msg = "DOM charges of source {!r} ({!r}) have an unexpected "
-                msg += "shape {!r}."
-                raise ValueError(msg.format(name, base, dom_charges_i.shape))
-
-            if dom_charges_variance_i.shape[1:] != [86, 60, 1]:
-                msg = "DOM charge variances of source {!r} ({!r}) have an "
-                msg += "unexpected shape {!r}."
-                raise ValueError(msg.format(name, base, dom_charges_i.shape))
-
-            if time_exclusions_exist:
-                dom_cdf_exclusion_sum_i = result_tensors_i[
-                    "dom_cdf_exclusion_sum"
-                ]
-                if dom_cdf_exclusion_sum_i.shape[1:] != [86, 60, 1]:
-                    msg = "DOM exclusions of source {!r} ({!r}) have an  "
-                    msg += "unexpected shape {!r}."
-                    raise ValueError(
-                        msg.format(name, base, dom_cdf_exclusion_sum_i.shape)
-                    )
-
-            # reshape to: [n_sources, n_batch, 86, 60, 1]
-            dom_charges_i = tf.reshape(
-                dom_charges_i, [n_sources, -1, 86, 60, 1]
-            )
-            dom_charges_variance_i = tf.reshape(
-                dom_charges_variance_i, [n_sources, -1, 86, 60, 1]
-            )
-
-            # reshape to: [n_sources, n_pulses]
-            pulse_pdf_i = tf.reshape(pulse_pdf_i, [n_sources, -1])
-
-            if time_exclusions_exist:
-                dom_cdf_exclusion_sum_i = tf.reshape(
-                    dom_cdf_exclusion_sum_i, [n_sources, -1, 86, 60, 1]
-                )
-
-            # accumulate charge
-            # (assumes that sources are linear and independent)
-            if dom_charges is None:
-                dom_charges = tf.reduce_sum(dom_charges_i, axis=0)
-                dom_charges_variance = tf.reduce_sum(
-                    dom_charges_variance_i, axis=0
-                )
-                if time_exclusions_exist:
-                    dom_cdf_exclusion_sum = tf.reduce_sum(
-                        (dom_cdf_exclusion_sum_i * dom_charges_i), axis=0
-                    )
-            else:
-                dom_charges += tf.reduce_sum(dom_charges_i, axis=0)
-                dom_charges_variance += tf.reduce_sum(
-                    dom_charges_variance_i, axis=0
-                )
-                if time_exclusions_exist:
-                    dom_cdf_exclusion_sum += tf.reduce_sum(
-                        (dom_cdf_exclusion_sum_i * dom_charges_i), axis=0
-                    )
-
-            # accumulate likelihood values
-            # (reweight by fraction of charge of source i vs total DOM charge)
-            pulse_weight_i = tf.gather_nd(
-                # shape: [n_sources * n_batch, 86, 60]
-                tf.squeeze(result_tensors_i["dom_charges"], axis=3),
-                # shape: [n_sources * n_pulses, 3], indexes to [b_i, s_i, d_i]
-                x_pulses_ids_i,
-            )
-            # reshape to: [n_sources, n_pulses]
-            pulse_weight_i = tf.reshape(pulse_weight_i, [n_sources, -1])
-
-            if pulse_pdf is None:
-                pulse_pdf = tf.reduce_sum(pulse_pdf_i * pulse_weight_i, axis=0)
-            else:
-                pulse_pdf += tf.reduce_sum(
-                    pulse_pdf_i * pulse_weight_i, axis=0
-                )
-
-        # normalize pulse_pdf values: divide by total charge at DOM
-        pulse_weight_total = tf.gather_nd(
-            tf.squeeze(dom_charges, axis=3), pulses_ids
-        )
-
-        pulse_pdf /= pulse_weight_total + 1e-6
-
-        result_tensors = {
-            "dom_charges": dom_charges,
-            "dom_charges_variance": dom_charges_variance,
-            "pulse_pdf": pulse_pdf,
-        }
-
-        # normalize time exclusion sum: divide by total charge at DOM
-        if time_exclusions_exist:
-            dom_cdf_exclusion_sum /= dom_charges
-
-            result_tensors["dom_cdf_exclusion_sum"] = dom_cdf_exclusion_sum
-
+            if all_models_have_cdf_values:
+                result_tensors["pulse_cdf"] /= 1.0 - pulse_cdf_exclusion + 1e-3
         return result_tensors
 
     def save_weights(

--- a/egenerator/model/source/base.py
+++ b/egenerator/model/source/base.py
@@ -110,14 +110,13 @@ class Source(Model):
 
     @property
     def epsilon(self):
-        if "float_precision" in self.configuration.config["config"]:
-            model_precision = self.configuration.config["config"][
-                "float_precision"
-            ]
+        config = self.configuration.config["config"]
+        if "float_precision" in config:
+            model_precision = config["float_precision"]
 
-        elif "sources" in self.configuration.config:
+        elif "sources" in config:
             model_precisions = []
-            for source in self.configuration.config["sources"]:
+            for source in config["sources"]:
                 model_precisions.append(
                     self.sub_components[source].configuration.config["config"][
                         "float_precision"
@@ -134,7 +133,7 @@ class Source(Model):
                 model_precision = model_precisions[0]
         else:
             raise ValueError(
-                "No float precision found in configuration: {self.configuration.config}"
+                f"No float precision found in configuration: {config}"
             )
 
         if model_precision == "float32":

--- a/egenerator/model/source/base.py
+++ b/egenerator/model/source/base.py
@@ -108,6 +108,21 @@ class Source(Model):
         else:
             return None
 
+    @property
+    def epsilon(self):
+        if self.configuration.config["config"]["float_precision"] == "float32":
+            return 1e-7
+        elif (
+            self.configuration.config["config"]["float_precision"] == "float64"
+        ):
+            return 1e-15
+        else:
+            raise ValueError(
+                "Invalid float precision: {}".format(
+                    self.configuration.config["config"]["float_precision"]
+                )
+            )
+
     def __init__(self, logger=None):
         """Instantiate Source class
 
@@ -437,6 +452,7 @@ class Source(Model):
             If asymmetric Gaussian latent variables are not present in
             `result_tensors` dictionary.
         """
+        eps = 1e-7
 
         x_orig = np.atleast_1d(x)
         assert len(x_orig.shape) == 1, x_orig.shape
@@ -495,7 +511,7 @@ class Source(Model):
             ].numpy()[:, strings, doms, ..., np.newaxis]
 
             # shape: [n_events, n_strings, n_doms, 1, 1]
-            scale /= 1.0 - dom_cdf_exclusion_sum + 1e-3
+            scale /= 1.0 - dom_cdf_exclusion_sum + eps
 
         # shape: [n_events, n_strings, n_doms, n_points]
         cdf_values = np.sum(mixture_cdf * scale, axis=3)
@@ -640,6 +656,7 @@ class Source(Model):
             If asymmetric Gaussian latent variables are not present in
             `result_tensors` dictionary.
         """
+        eps = 1e-7
 
         x_orig = np.atleast_1d(x)
         assert len(x_orig.shape) == 1, x_orig.shape
@@ -695,7 +712,7 @@ class Source(Model):
             ].numpy()[:, strings, doms, ..., np.newaxis]
 
             # shape: [n_events, n_strings, n_doms, 1, 1]
-            scale /= 1.0 - dom_cdf_exclusion_sum + 1e-3
+            scale /= 1.0 - dom_cdf_exclusion_sum + eps
 
         # shape: [n_events, n_strings, n_doms, n_points]
         pdf_values = np.sum(mixture_pdf * scale, axis=3)

--- a/egenerator/model/source/base.py
+++ b/egenerator/model/source/base.py
@@ -116,11 +116,11 @@ class Source(Model):
 
         elif "sources" in config:
             model_precisions = []
-            for source in config["sources"]:
+            for _, base_source in config["sources"].items():
                 model_precisions.append(
-                    self.sub_components[source].configuration.config["config"][
-                        "float_precision"
-                    ]
+                    self.sub_components[base_source].configuration.config[
+                        "config"
+                    ]["float_precision"]
                 )
             model_precisions = np.unique(model_precisions)
             if len(model_precisions) > 1:
@@ -405,6 +405,7 @@ class Source(Model):
         tw_exclusions_ids=None,
         strings=slice(None),
         doms=slice(None),
+        dtype="float64",
         **kwargs
     ):
         """Compute CDF values at x for given result_tensors
@@ -457,6 +458,9 @@ class Source(Model):
             The doms to slice the PDF for.
             If None, all doms are used.
             Shape: [n_doms]
+        dtype : str, optional
+            The data type of the output array.
+            Default: 'float64'
         **kwargs
             Keyword arguments.
 
@@ -474,7 +478,12 @@ class Source(Model):
             If asymmetric Gaussian latent variables are not present in
             `result_tensors` dictionary.
         """
-        eps = 1e-7
+        if dtype == "float64":
+            eps = 1e-15
+        elif dtype == "float32":
+            eps = 1e-7
+        else:
+            raise ValueError(f"Invalid dtype: {dtype}")
 
         x_orig = np.atleast_1d(x)
         assert len(x_orig.shape) == 1, x_orig.shape
@@ -521,7 +530,11 @@ class Source(Model):
 
         # shape: [n_events, n_strings, n_doms, n_components, n_points]
         mixture_cdf = basis_functions.asymmetric_gauss_cdf(
-            x=x, mu=mu, sigma=sigma, r=r
+            x=x,
+            mu=mu,
+            sigma=sigma,
+            r=r,
+            dtype=dtype,
         )
 
         # uniformly scale up pdf values due to excluded regions
@@ -573,6 +586,7 @@ class Source(Model):
                             sigma[ids[0], ids[1], ids[2]], [1, 1, -1]
                         ),
                         r=np.reshape(r[ids[0], ids[1], ids[2]], [1, 1, -1]),
+                        dtype=dtype,
                     )
                     * np.reshape(scale[ids[0], ids[1], ids[2]], [1, 1, -1]),
                     axis=2,
@@ -585,7 +599,7 @@ class Source(Model):
 
                 cdf_values[ids[0], ids[1], ids[2]] -= cdf_excluded
 
-            eps = 1e-3
+            eps = 1e-6
             if (cdf_values < 0 - eps).any():
                 self._logger.warning(
                     "CDF values below zero: {}".format(
@@ -609,6 +623,7 @@ class Source(Model):
         tw_exclusions_ids=None,
         strings=slice(None),
         doms=slice(None),
+        dtype="float64",
         **kwargs
     ):
         """Compute PDF values at x for given result_tensors
@@ -678,7 +693,12 @@ class Source(Model):
             If asymmetric Gaussian latent variables are not present in
             `result_tensors` dictionary.
         """
-        eps = 1e-7
+        if dtype == "float64":
+            eps = 1e-15
+        elif dtype == "float32":
+            eps = 1e-7
+        else:
+            raise ValueError(f"Invalid dtype: {dtype}")
 
         x_orig = np.atleast_1d(x)
         assert len(x_orig.shape) == 1, x_orig.shape
@@ -722,7 +742,11 @@ class Source(Model):
 
         # shape: [n_events, n_strings, n_doms, n_components, n_points]
         mixture_pdf = basis_functions.asymmetric_gauss(
-            x=x, mu=mu, sigma=sigma, r=r
+            x=x,
+            mu=mu,
+            sigma=sigma,
+            r=r,
+            dtype=dtype,
         )
 
         # uniformly scale up pdf values due to excluded regions

--- a/egenerator/model/source/cascade/default.py
+++ b/egenerator/model/source/cascade/default.py
@@ -567,8 +567,8 @@ class DefaultCascadeModel(Source):
 
         # force positive and min values
         latent_scale = tf.nn.elu(latent_scale) + 1.00001
-        latent_r = tf.nn.elu(latent_r) + 1.001
-        latent_sigma = tf.nn.elu(latent_sigma) + 1.001
+        latent_r = tf.nn.elu(latent_r) + 1.0001
+        latent_sigma = tf.nn.elu(latent_sigma) + 1.0001
 
         # normalize scale to sum to 1
         latent_scale /= tf.reduce_sum(latent_scale, axis=-1, keepdims=True)
@@ -621,17 +621,22 @@ class DefaultCascadeModel(Source):
                 mu=tw_latent_mu,
                 sigma=tw_latent_sigma,
                 r=tw_latent_r,
+                dtype=config["float_precision_pdf_cdf"],
             )
             tw_cdf_stop = basis_functions.tf_asymmetric_gauss_cdf(
                 x=t_exclusions[:, 1],
                 mu=tw_latent_mu,
                 sigma=tw_latent_sigma,
                 r=tw_latent_r,
+                dtype=config["float_precision_pdf_cdf"],
             )
 
             # shape: [n_tw, n_models]
             tw_cdf_exclusion = tf_helpers.safe_cdf_clip(
                 tw_cdf_stop - tw_cdf_start
+            )
+            tw_cdf_exclusion = tf.cast(
+                tw_cdf_exclusion, dtype=config["float_precision"]
             )
 
             # shape: [n_tw, 1]
@@ -772,16 +777,19 @@ class DefaultCascadeModel(Source):
             # shape: [n_batch, 86, 60, 1]
             dom_charges_llh = tf.where(
                 dom_charges_true > charge_threshold,
-                tf.math.log(
-                    basis_functions.tf_asymmetric_gauss(
-                        x=dom_charges_true,
-                        mu=dom_charges,
-                        sigma=dom_charges_sigma,
-                        r=dom_charges_r,
-                    )
-                    + self.epsilon
+                tf.cast(
+                    tf_helpers.safe_log(
+                        basis_functions.tf_asymmetric_gauss(
+                            x=dom_charges_true,
+                            mu=dom_charges,
+                            sigma=dom_charges_sigma,
+                            r=dom_charges_r,
+                            dtype=config["float_precision_pdf_cdf"],
+                        )
+                    ),
+                    dtype=config["float_precision"],
                 ),
-                dom_charges_true * tf.math.log(dom_charges + self.epsilon)
+                dom_charges_true * tf_helpers.safe_log(dom_charges)
                 - dom_charges,
             )
 
@@ -822,10 +830,14 @@ class DefaultCascadeModel(Source):
             dom_charges_alpha = tf.nn.elu(alpha_trafo - 5) + 1.000001
 
             # compute log pdf
-            dom_charges_llh = basis_functions.tf_log_negative_binomial(
-                x=dom_charges_true,
-                mu=dom_charges,
-                alpha=dom_charges_alpha,
+            dom_charges_llh = tf.cast(
+                basis_functions.tf_log_negative_binomial(
+                    x=dom_charges_true,
+                    mu=dom_charges,
+                    alpha=dom_charges_alpha,
+                    dtype=config["float_precision_pdf_cdf"],
+                ),
+                dtype=config["float_precision"],
             )
 
             # compute standard deviation
@@ -877,6 +889,10 @@ class DefaultCascadeModel(Source):
         # Apply Asymmetric Gaussian Mixture Model
         # -------------------------------------------
 
+        pulse_latent_scale = tf.cast(
+            pulse_latent_scale, dtype=config["float_precision_pdf_cdf"]
+        )
+
         # [n_pulses, 1] * [n_pulses, n_models] = [n_pulses, n_models]
         pulse_pdf_values = (
             basis_functions.tf_asymmetric_gauss(
@@ -884,6 +900,7 @@ class DefaultCascadeModel(Source):
                 mu=pulse_latent_mu,
                 sigma=pulse_latent_sigma,
                 r=pulse_latent_r,
+                dtype=config["float_precision_pdf_cdf"],
             )
             * pulse_latent_scale
         )
@@ -893,6 +910,7 @@ class DefaultCascadeModel(Source):
                 mu=pulse_latent_mu,
                 sigma=pulse_latent_sigma,
                 r=pulse_latent_r,
+                dtype=config["float_precision_pdf_cdf"],
             )
             * pulse_latent_scale
         )
@@ -900,6 +918,14 @@ class DefaultCascadeModel(Source):
         # new shape: [n_pulses]
         pulse_pdf_values = tf.reduce_sum(pulse_pdf_values, axis=-1)
         pulse_cdf_values = tf.reduce_sum(pulse_cdf_values, axis=-1)
+
+        # cast back to specified float precision
+        pulse_pdf_values = tf.cast(
+            pulse_pdf_values, dtype=config["float_precision"]
+        )
+        pulse_cdf_values = tf.cast(
+            pulse_cdf_values, dtype=config["float_precision"]
+        )
 
         # scale up pulse pdf by time exclusions if needed
         if time_exclusions_exist:

--- a/egenerator/model/source/cascade/default.py
+++ b/egenerator/model/source/cascade/default.py
@@ -154,9 +154,9 @@ class DefaultCascadeModel(Source):
                 The input pulses (charge, time) of all events in a batch.
                 Shape: [-1, 2]
             pulses_ids : tf.Tensor
-                The pulse indices (batch_index, string, dom) of all pulses in
-                the batch of events.
-                Shape: [-1, 3]
+                The pulse indices (batch_index, string, dom, pulse_number)
+                of all pulses in the batch of events.
+                Shape: [-1, 4]
         is_training : bool, optional
             Indicates whether currently in training or inference mode.
             Must be provided if batch normalisation is used.
@@ -183,6 +183,11 @@ class DefaultCascadeModel(Source):
                     Shape: [-1, 86, 60]
                 'pulse_pdf': The likelihood evaluated for each pulse
                              Shape: [-1]
+            Optional:
+
+                'pulse_cdf': The cumulative likelihood evaluated
+                             for each pulse
+                             Shape: [-1]
         """
         self.assert_configured(True)
 
@@ -192,7 +197,7 @@ class DefaultCascadeModel(Source):
         config = self.configuration.config["config"]
         parameters = data_batch_dict[parameter_tensor_name]
         pulses = data_batch_dict["x_pulses"]
-        pulses_ids = data_batch_dict["x_pulses_ids"]
+        pulses_ids = data_batch_dict["x_pulses_ids"][:, :3]
 
         tensors = self.data_trafo.data["tensors"]
         if (
@@ -953,9 +958,19 @@ class DefaultCascadeModel(Source):
             )
             * pulse_latent_scale
         )
+        pulse_cdf_values = (
+            basis_functions.tf_asymmetric_gauss_cdf(
+                x=t_pdf,
+                mu=pulse_latent_mu,
+                sigma=pulse_latent_sigma,
+                r=pulse_latent_r,
+            )
+            * pulse_latent_scale
+        )
 
         # new shape: [n_pulses]
         pulse_pdf_values = tf.reduce_sum(pulse_pdf_values, axis=-1)
+        pulse_cdf_values = tf.reduce_sum(pulse_cdf_values, axis=-1)
 
         # scale up pulse pdf by time exclusions if needed
         if time_exclusions_exist:
@@ -967,8 +982,10 @@ class DefaultCascadeModel(Source):
 
             # Shape: [n_pulses]
             pulse_pdf_values /= 1.0 - pulse_cdf_exclusion + 1e-3
+            pulse_cdf_values /= 1.0 - pulse_cdf_exclusion + 1e-3
 
         tensor_dict["pulse_pdf"] = pulse_pdf_values
+        tensor_dict["pulse_cdf"] = pulse_cdf_values
         # ---------------------
 
         return tensor_dict

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -676,6 +676,7 @@ class EnteringSphereInfTrack(Source):
             tw_latent_mu = tf.gather_nd(latent_mu, x_time_exclusions_ids)
             tw_latent_sigma = tf.gather_nd(latent_sigma, x_time_exclusions_ids)
             tw_latent_r = tf.gather_nd(latent_r, x_time_exclusions_ids)
+            tw_latent_scale = tf.gather_nd(latent_scale, x_time_exclusions_ids)
 
             # ensure shapes
             tw_latent_mu = tf.ensure_shape(tw_latent_mu, [None, n_models])
@@ -683,6 +684,9 @@ class EnteringSphereInfTrack(Source):
                 tw_latent_sigma, [None, n_models]
             )
             tw_latent_r = tf.ensure_shape(tw_latent_r, [None, n_models])
+            tw_latent_scale = tf.ensure_shape(
+                tw_latent_scale, [None, n_models]
+            )
 
             # [n_tw, 1] * [n_tw, n_models] = [n_tw, n_models]
             tw_cdf_start = basis_functions.tf_asymmetric_gauss_cdf(
@@ -698,8 +702,14 @@ class EnteringSphereInfTrack(Source):
                 r=tw_latent_r,
             )
 
+            # shape: [n_tw, n_models]
             tw_cdf_exclusion = tf_helpers.safe_cdf_clip(
                 tw_cdf_stop - tw_cdf_start
+            )
+
+            # shape: [n_tw, 1]
+            tw_cdf_exclusion_reduced = tf.reduce_sum(
+                tw_cdf_exclusion * tw_latent_scale, axis=-1
             )
 
             # accumulate time window exclusions for each DOM and MM component
@@ -966,13 +976,23 @@ class EnteringSphereInfTrack(Source):
         if time_exclusions_exist:
 
             # Shape: [n_pulses, 1] -> squeeze -> [n_pulses]
-            pulse_cdf_exclusion = tf.squeeze(
+            pulse_cdf_exclusion_total = tf.squeeze(
                 tf.gather_nd(dom_cdf_exclusion_sum, pulses_ids), axis=1
             )
 
+            # subtract excluded regions from cdf values
+            pulse_cdf_exclusion = tf_helpers.get_pulse_cdf_exclusion(
+                x_pulses=pulses,
+                x_pulses_ids=pulses_ids,
+                x_time_exclusions=x_time_exclusions,
+                x_time_exclusions_ids=x_time_exclusions_ids,
+                tw_cdf_exclusion_reduced=tw_cdf_exclusion_reduced,
+            )
+            pulse_cdf_values -= pulse_cdf_exclusion
+
             # Shape: [n_pulses]
-            pulse_pdf_values /= 1.0 - pulse_cdf_exclusion + self.epsilon
-            pulse_cdf_values /= 1.0 - pulse_cdf_exclusion + self.epsilon
+            pulse_pdf_values /= 1.0 - pulse_cdf_exclusion_total + self.epsilon
+            pulse_cdf_values /= 1.0 - pulse_cdf_exclusion_total + self.epsilon
 
         tensor_dict["pulse_pdf"] = pulse_pdf_values
         tensor_dict["pulse_cdf"] = pulse_cdf_values

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -637,9 +637,9 @@ class EnteringSphereInfTrack(Source):
         latent_mu = dt_geometry + t_seed + factor_mu * latent_mu
 
         # force positive and min values
-        latent_scale = tf.nn.elu(latent_scale) + 1.00001
-        latent_r = tf.nn.elu(latent_r) + 1.001
-        latent_sigma = tf.nn.elu(latent_sigma) + 1.001
+        latent_scale = tf.math.exp(latent_scale)
+        latent_r = tf.math.exp(latent_r)
+        latent_sigma = tf.math.exp(latent_sigma) + 0.0001
 
         # normalize scale to sum to 1
         latent_scale /= tf.reduce_sum(latent_scale, axis=-1, keepdims=True)
@@ -877,7 +877,7 @@ class EnteringSphereInfTrack(Source):
 
             # create correct offset and force positive and min values
             # The over-dispersion parameterized by alpha must be greater zero
-            dom_charges_alpha = tf.nn.elu(alpha_trafo - 5) + 1.000001
+            dom_charges_alpha = tf.math.exp(alpha_trafo - 5) + 0.000001
 
             # compute log pdf
             dom_charges_llh = basis_functions.tf_log_negative_binomial(

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -346,7 +346,9 @@ class EnteringSphereInfTrack(Source):
         # calculate opening angle of cherenkov light and PMT direction
         # shape: [n_batch, 86, 60, 1]
         opening_angle = angles.get_angle(
-            tf.stack([0.0, 0.0, 1.0], axis=-1),
+            tf.stack([0.0, 0.0, 1.0], axis=-1).astype(
+                config["float_precision"]
+            ),
             tf.concat(
                 [
                     dx_cherenkov_normed,

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -346,8 +346,8 @@ class EnteringSphereInfTrack(Source):
         # calculate opening angle of cherenkov light and PMT direction
         # shape: [n_batch, 86, 60, 1]
         opening_angle = angles.get_angle(
-            tf.stack([0.0, 0.0, 1.0], axis=-1).astype(
-                config["float_precision"]
+            tf.cast(
+                tf.stack([0.0, 0.0, 1.0], axis=-1), config["float_precision"]
             ),
             tf.concat(
                 [

--- a/egenerator/model/source/track/inf_tracks_sphere.py
+++ b/egenerator/model/source/track/inf_tracks_sphere.py
@@ -777,10 +777,12 @@ class EnteringSphereInfTrack(Source):
 
         # apply time window exclusions if needed
         if time_exclusions_exist:
-            dom_charges = dom_charges * (1.0 - dom_cdf_exclusion_sum + 1e-3)
+            dom_charges = dom_charges * (
+                1.0 - dom_cdf_exclusion_sum + self.epsilon
+            )
 
         # add small constant to make sure dom charges are > 0:
-        dom_charges += 1e-7
+        dom_charges += self.epsilon
 
         tensor_dict["dom_charges"] = dom_charges
 
@@ -827,7 +829,6 @@ class EnteringSphereInfTrack(Source):
 
             # Apply Asymmetric Gaussian and/or Poisson Likelihood
             # shape: [n_batch, 86, 60, 1]
-            eps = 1e-7
             dom_charges_llh = tf.where(
                 dom_charges_true > charge_threshold,
                 tf.math.log(
@@ -837,9 +838,9 @@ class EnteringSphereInfTrack(Source):
                         sigma=dom_charges_sigma,
                         r=dom_charges_r,
                     )
-                    + eps
+                    + self.epsilon
                 ),
-                dom_charges_true * tf.math.log(dom_charges + eps)
+                dom_charges_true * tf.math.log(dom_charges + self.epsilon)
                 - dom_charges,
             )
 
@@ -849,7 +850,7 @@ class EnteringSphereInfTrack(Source):
                 # take mean of left and right side uncertainty
                 # Note: this might not be correct
                 dom_charges_sigma * ((1 + dom_charges_r) / 2.0),
-                tf.math.sqrt(dom_charges + eps),
+                tf.math.sqrt(dom_charges + self.epsilon),
             )
 
             # add tensors to tensor dictionary
@@ -968,8 +969,8 @@ class EnteringSphereInfTrack(Source):
             )
 
             # Shape: [n_pulses]
-            pulse_pdf_values /= 1.0 - pulse_cdf_exclusion + 1e-3
-            pulse_cdf_values /= 1.0 - pulse_cdf_exclusion + 1e-3
+            pulse_pdf_values /= 1.0 - pulse_cdf_exclusion + self.epsilon
+            pulse_cdf_values /= 1.0 - pulse_cdf_exclusion + self.epsilon
 
         tensor_dict["pulse_pdf"] = pulse_pdf_values
         tensor_dict["pulse_cdf"] = pulse_cdf_values

--- a/egenerator/model/source/track/stochastic_segment.py
+++ b/egenerator/model/source/track/stochastic_segment.py
@@ -19,6 +19,11 @@ class StochasticTrackSegmentModel(Source):
         logger : logging.logger, optional
             The logger to use.
         """
+        raise NotImplementedError(
+            "This class has not been cross-checked. "
+            "It may require updates for newest egenerator version. "
+            "This is still a ToDo"
+        )
         self._logger = logger or logging.getLogger(__name__)
         super(StochasticTrackSegmentModel, self).__init__(logger=self._logger)
 

--- a/egenerator/model/source/track/stochastic_segment.py
+++ b/egenerator/model/source/track/stochastic_segment.py
@@ -206,9 +206,9 @@ class StochasticTrackSegmentModel(Source):
                 The input pulses (charge, time) of all events in a batch.
                 Shape: [-1, 2]
             pulses_ids : tf.Tensor
-                The pulse indices (batch_index, string, dom) of all pulses in
-                the batch of events.
-                Shape: [-1, 3]
+                The pulse indices (batch_index, string, dom, pulse_number)
+                of all pulses in the batch of events.
+                Shape: [-1, 4]
         is_training : bool, optional
             Indicates whether currently in training or inference mode.
             Must be provided if batch normalisation is used.
@@ -243,7 +243,7 @@ class StochasticTrackSegmentModel(Source):
         config = self.configuration.config["config"]
         parameters = data_batch_dict[parameter_tensor_name]
         pulses = data_batch_dict["x_pulses"]
-        pulses_ids = data_batch_dict["x_pulses_ids"]
+        pulses_ids = data_batch_dict["x_pulses_ids"][:, :3]
 
         # shape: [n_batch, 86, 60, 1]
         dom_charges_true = data_batch_dict["x_dom_charge"]

--- a/egenerator/reconstruct_test_data.py
+++ b/egenerator/reconstruct_test_data.py
@@ -28,7 +28,7 @@ from egenerator.data.modules.misc.seed_loader import SeedLoaderMiscModule
     type=click.Choice(["DEBUG", "INFO", "WARNING"]),
     default="WARNING",
 )
-def main(config_files, reco_config_file=None, log_level="INFO"):
+def main(config_files, reco_config_file=None, log_level="INFO", num_threads=0):
     """Script to train model.
 
     Parameters
@@ -42,6 +42,10 @@ def main(config_files, reco_config_file=None, log_level="INFO"):
         If None, then the first provided config file will be used.
     log_level : str, optional
         The logging level.
+    num_threads : int, optional
+        Number of threads to use for tensorflow settings
+        `intra_op_parallelism_threads` and `inter_op_parallelism_threads`.
+        If zero (default), the system picks an appropriate number.
 
     Raises
     ------
@@ -61,6 +65,10 @@ def main(config_files, reco_config_file=None, log_level="INFO"):
     gpu_devices = tf.config.list_physical_devices("GPU")
     for device in gpu_devices:
         tf.config.experimental.set_memory_growth(device, True)
+
+    # limit number of CPU threads
+    tf.config.threading.set_intra_op_parallelism_threads(num_threads)
+    tf.config.threading.set_inter_op_parallelism_threads(num_threads)
 
     # read in reconstruction config file
     setup_manager = SetupManager(reco_config_file)

--- a/egenerator/reconstruct_test_data.py
+++ b/egenerator/reconstruct_test_data.py
@@ -28,6 +28,11 @@ from egenerator.data.modules.misc.seed_loader import SeedLoaderMiscModule
     type=click.Choice(["DEBUG", "INFO", "WARNING"]),
     default="WARNING",
 )
+@click.option(
+    "--num_threads",
+    type=int,
+    default=0,
+)
 def main(config_files, reco_config_file=None, log_level="INFO", num_threads=0):
     """Script to train model.
 

--- a/egenerator/train_model.py
+++ b/egenerator/train_model.py
@@ -19,6 +19,11 @@ from egenerator.utils.build_components import build_loss_module
     type=click.Choice(["DEBUG", "INFO", "WARNING"]),
     default="WARNING",
 )
+@click.option(
+    "--num_threads",
+    type=int,
+    default=0,
+)
 def main(config_files, log_level, num_threads=0):
     """Script to train model.
 

--- a/egenerator/train_model.py
+++ b/egenerator/train_model.py
@@ -19,7 +19,7 @@ from egenerator.utils.build_components import build_loss_module
     type=click.Choice(["DEBUG", "INFO", "WARNING"]),
     default="WARNING",
 )
-def main(config_files, log_level):
+def main(config_files, log_level, num_threads=0):
     """Script to train model.
 
     Parameters
@@ -28,6 +28,10 @@ def main(config_files, log_level):
         List of yaml config files.
     log_level : str
         The logging level.
+    num_threads : int, optional
+        Number of threads to use for tensorflow settings
+        `intra_op_parallelism_threads` and `inter_op_parallelism_threads`.
+        If zero (default), the system picks an appropriate number.
     """
 
     # set up logging
@@ -37,6 +41,10 @@ def main(config_files, log_level):
     gpu_devices = tf.config.list_physical_devices("GPU")
     for device in gpu_devices:
         tf.config.experimental.set_memory_growth(device, True)
+
+    # limit number of CPU threads
+    tf.config.threading.set_intra_op_parallelism_threads(num_threads)
+    tf.config.threading.set_inter_op_parallelism_threads(num_threads)
 
     # read in and combine config files and set up
     setup_manager = SetupManager(config_files)

--- a/egenerator/utils/basis_functions.py
+++ b/egenerator/utils/basis_functions.py
@@ -5,7 +5,49 @@ from scipy import stats
 from scipy.integrate import quad
 
 
-def tf_gauss(x, mu, sigma):
+def cast(dtype, *args):
+    """Cast all input arguments to the provided data type.
+
+    Parameters
+    ----------
+    dtype : str
+        The data type to cast the inputs to.
+        If None, no casting is performed.
+    *args : array_like
+        The input arguments to cast.
+
+    Returns
+    -------
+    array_like
+        The casted input arguments.
+    """
+    if dtype is None:
+        return args
+    return tuple(np.array(arg, dtype=dtype) for arg in args)
+
+
+def tf_cast(dtype, *args):
+    """Cast all input arguments to the provided data type.
+
+    Parameters
+    ----------
+    dtype : str
+        The data type to cast the inputs to.
+        If None, no casting is performed.
+    *args : tf.Tensor
+        The input arguments to cast.
+
+    Returns
+    -------
+    tf.Tensor
+        The casted input arguments.
+    """
+    if dtype is None:
+        return args
+    return tuple(tf.cast(arg, dtype) for arg in args)
+
+
+def tf_gauss(x, mu, sigma, dtype=None):
     """Gaussian PDF
 
     Parameters
@@ -16,18 +58,22 @@ def tf_gauss(x, mu, sigma):
         Mu parameter of Gaussian.
     sigma : tf.Tensor
         Sigma parameter of Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The Gaussian PDF evaluated at x
     """
+    x, mu, sigma = tf_cast(dtype, x, mu, sigma)
     return (
         tf.exp(-0.5 * ((x - mu) / sigma) ** 2) / (2 * np.pi * sigma**2) ** 0.5
     )
 
 
-def gauss(x, mu, sigma):
+def gauss(x, mu, sigma, dtype=None):
     """Gaussian PDF
 
     Parameters
@@ -38,18 +84,22 @@ def gauss(x, mu, sigma):
         Mu parameter of Gaussian.
     sigma : array_like
         Sigma parameter of Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The Gaussian PDF evaluated at x
     """
+    x, mu, sigma = cast(dtype, x, mu, sigma)
     return (
         np.exp(-0.5 * ((x - mu) / sigma) ** 2) / (2 * np.pi * sigma**2) ** 0.5
     )
 
 
-def tf_log_gauss(x, mu, sigma):
+def tf_log_gauss(x, mu, sigma, dtype=None):
     """Log Gaussian PDF
 
     Parameters
@@ -60,17 +110,21 @@ def tf_log_gauss(x, mu, sigma):
         Mu parameter of Gaussian.
     sigma : tf.Tensor
         Sigma parameter of Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The Gaussian PDF evaluated at x
     """
+    x, mu, sigma = tf_cast(dtype, x, mu, sigma)
     norm = np.log(np.sqrt(2 * np.pi))
     return -0.5 * ((x - mu) / sigma) ** 2 - tf.math.log(sigma) - norm
 
 
-def log_gauss(x, mu, sigma):
+def log_gauss(x, mu, sigma, dtype=None):
     """Log Gaussian PDF
 
     Parameters
@@ -81,17 +135,21 @@ def log_gauss(x, mu, sigma):
         Mu parameter of Gaussian.
     sigma : array_like
         Sigma parameter of Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The Gaussian PDF evaluated at x
     """
+    x, mu, sigma = cast(dtype, x, mu, sigma)
     norm = np.log(np.sqrt(2 * np.pi))
     return -0.5 * ((x - mu) / sigma) ** 2 - np.log(sigma) - norm
 
 
-def tf_log_asymmetric_gauss(x, mu, sigma, r):
+def tf_log_asymmetric_gauss(x, mu, sigma, r, dtype=None):
     """Asymmetric Log Gaussian PDF
 
     Parameters
@@ -104,12 +162,16 @@ def tf_log_asymmetric_gauss(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : tf.Tensor
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The asymmetric Gaussian PDF evaluated at x
     """
+    x, mu, sigma, r = tf_cast(dtype, x, mu, sigma, r)
     norm = tf.math.log(2.0 / (tf.sqrt(2 * np.pi * sigma**2) * (r + 1)))
     exp = tf.where(
         x < mu,
@@ -119,7 +181,7 @@ def tf_log_asymmetric_gauss(x, mu, sigma, r):
     return norm + exp
 
 
-def log_asymmetric_gauss(x, mu, sigma, r):
+def log_asymmetric_gauss(x, mu, sigma, r, dtype=None):
     """Asymmetric Log Gaussian PDF
 
     Parameters
@@ -132,12 +194,16 @@ def log_asymmetric_gauss(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : array_like
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The asymmetric Gaussian PDF evaluated at x
     """
+    x, mu, sigma, r = cast(dtype, x, mu, sigma, r)
     norm = np.log(2.0 / (np.sqrt(2 * np.pi * sigma**2) * (r + 1)))
     exp = np.where(
         x < mu,
@@ -147,7 +213,7 @@ def log_asymmetric_gauss(x, mu, sigma, r):
     return norm + exp
 
 
-def tf_asymmetric_gauss(x, mu, sigma, r):
+def tf_asymmetric_gauss(x, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian PDF
 
     Parameters
@@ -160,12 +226,16 @@ def tf_asymmetric_gauss(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : tf.Tensor
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The asymmetric Gaussian PDF evaluated at x
     """
+    x, mu, sigma, r = tf_cast(dtype, x, mu, sigma, r)
     norm = 2.0 / (tf.sqrt(2 * np.pi * sigma**2) * (r + 1))
     exp = tf.where(
         x < mu,
@@ -175,7 +245,7 @@ def tf_asymmetric_gauss(x, mu, sigma, r):
     return norm * exp
 
 
-def asymmetric_gauss(x, mu, sigma, r):
+def asymmetric_gauss(x, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian PDF
 
     Parameters
@@ -188,12 +258,16 @@ def asymmetric_gauss(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : array_like
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The asymmetric Gaussian PDF evaluated at x
     """
+    x, mu, sigma, r = cast(dtype, x, mu, sigma, r)
     norm = 2.0 / (np.sqrt(2 * np.pi * sigma**2) * (r + 1))
     exp = np.where(
         x < mu,
@@ -203,7 +277,7 @@ def asymmetric_gauss(x, mu, sigma, r):
     return norm * exp
 
 
-def tf_asymmetric_gauss_cdf(x, mu, sigma, r):
+def tf_asymmetric_gauss_cdf(x, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian CDF
 
     Parameters
@@ -216,12 +290,16 @@ def tf_asymmetric_gauss_cdf(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : tf.Tensor
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The asymmetric Gaussian CDF evaluated at x
     """
+    x, mu, sigma, r = tf_cast(dtype, x, mu, sigma, r)
     norm = 1.0 / (r + 1)
     exp = tf.where(
         x < mu,
@@ -231,7 +309,7 @@ def tf_asymmetric_gauss_cdf(x, mu, sigma, r):
     return norm * exp
 
 
-def asymmetric_gauss_cdf(x, mu, sigma, r):
+def asymmetric_gauss_cdf(x, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian CDF
 
     Parameters
@@ -244,12 +322,16 @@ def asymmetric_gauss_cdf(x, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : array_like
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The asymmetric Gaussian CDF evaluated at x
     """
+    x, mu, sigma, r = cast(dtype, x, mu, sigma, r)
     norm = 1.0 / (r + 1)
     exp = np.where(
         x < mu,
@@ -259,7 +341,7 @@ def asymmetric_gauss_cdf(x, mu, sigma, r):
     return norm * exp
 
 
-def tf_asymmetric_gauss_ppf(q, mu, sigma, r):
+def tf_asymmetric_gauss_ppf(q, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian PPF
 
     Parameters
@@ -272,12 +354,16 @@ def tf_asymmetric_gauss_ppf(q, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : tf.Tensor
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The asymmetric Gaussian PPF evaluated at q
     """
+    q, mu, sigma, r = tf_cast(dtype, q, mu, sigma, r)
     return tf.where(
         q < 1.0 / (r + 1),
         mu + np.sqrt(2) * sigma * tf.math.erfinv(q * (r + 1) - 1),
@@ -285,7 +371,7 @@ def tf_asymmetric_gauss_ppf(q, mu, sigma, r):
     )
 
 
-def asymmetric_gauss_ppf(q, mu, sigma, r):
+def asymmetric_gauss_ppf(q, mu, sigma, r, dtype=None):
     """Asymmetric Gaussian PPF
 
     Parameters
@@ -298,12 +384,16 @@ def asymmetric_gauss_ppf(q, mu, sigma, r):
         Sigma parameter of Gaussian.
     r : array_like
         The asymmetry of the Gaussian.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The asymmetric Gaussian PPF evaluated at q
     """
+    q, mu, sigma, r = cast(dtype, q, mu, sigma, r)
     return np.where(
         q < 1.0 / (r + 1),
         mu + np.sqrt(2) * sigma * special.erfinv(q * (r + 1) - 1),
@@ -311,7 +401,9 @@ def asymmetric_gauss_ppf(q, mu, sigma, r):
     )
 
 
-def tf_log_negative_binomial(x, mu, alpha, add_normalization_term=False):
+def tf_log_negative_binomial(
+    x, mu, alpha, add_normalization_term=False, dtype=None
+):
     """Computes the logarithm of the negative binomial PDF
 
     The parameterization chosen here is defined by the mean mu and
@@ -339,12 +431,17 @@ def tf_log_negative_binomial(x, mu, alpha, add_normalization_term=False):
         binomial distribution only has a proper normalization for integer x.
         For real-valued x the negative binomial is not properly normalized and
         hence adding the normalization term does not help.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         Logarithm of the negative binomal PDF evaluated at x.
     """
+    x, mu, alpha = tf_cast(dtype, x, mu, alpha)
+
     inv_alpha = 1.0 / alpha
     alpha_mu = alpha * mu
 
@@ -360,7 +457,9 @@ def tf_log_negative_binomial(x, mu, alpha, add_normalization_term=False):
     return gamma_terms + term1 + term2
 
 
-def log_negative_binomial(x, mu, alpha, add_normalization_term=False):
+def log_negative_binomial(
+    x, mu, alpha, add_normalization_term=False, dtype=None
+):
     """Computes the logarithm of the negative binomial PDF
 
     The parameterization chosen here is defined by the mean mu and
@@ -395,12 +494,17 @@ def log_negative_binomial(x, mu, alpha, add_normalization_term=False):
         binomial distribution only has a proper normalization for integer x.
         For real-valued x the negative binomial is not properly normalized and
         hence adding the normalization term does not help.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         Logarithm of the negative binomal PDF evaluated at x.
     """
+    x, mu, alpha = cast(dtype, x, mu, alpha)
+
     inv_alpha = 1.0 / alpha
     alpha_mu = alpha * mu
 
@@ -508,7 +612,7 @@ def sample_from_negative_binomial(
     return rng.negative_binomial(r, p, size=size)
 
 
-def negative_binomial_cdf(x, mu, alpha_or_var, param_is_alpha):
+def negative_binomial_cdf(x, mu, alpha_or_var, param_is_alpha, dtype=None):
     """Computes the CDF of the negative binomial PDF
 
     The parameterization chosen here is defined by the mean mu and
@@ -537,19 +641,23 @@ def negative_binomial_cdf(x, mu, alpha_or_var, param_is_alpha):
     param_is_alpha : bool
         If True, the parameter passed as `alpha_or_var` is alpha.
         If False, the parameter passed as `alpha_or_var` is the variance.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         CDF of the negative binomal PDF evaluated at x.
     """
+    x, mu, alpha_or_var = cast(dtype, x, mu, alpha_or_var)
     p, r = convert_neg_binomial_params(
         mu=mu, alpha_or_var=alpha_or_var, param_is_alpha=param_is_alpha
     )
     return stats.nbinom(r, p).cdf(x)
 
 
-def negative_binomial_ppf(q, mu, alpha_or_var, param_is_alpha):
+def negative_binomial_ppf(q, mu, alpha_or_var, param_is_alpha, dtype=None):
     """Computes the PPF of the negative binomial PDF
 
     The parameterization chosen here is defined by the mean mu and
@@ -578,19 +686,23 @@ def negative_binomial_ppf(q, mu, alpha_or_var, param_is_alpha):
     param_is_alpha : bool
         If True, the parameter passed as `alpha_or_var` is alpha.
         If False, the parameter passed as `alpha_or_var` is the variance.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         PPF of the negative binomal PDF evaluated at x.
     """
+    mu, alpha_or_var = cast(dtype, mu, alpha_or_var)
     p, r = convert_neg_binomial_params(
         mu=mu, alpha_or_var=alpha_or_var, param_is_alpha=param_is_alpha
     )
     return stats.nbinom(r, p).ppf(q)
 
 
-def tf_rayleigh(x, sigma):
+def tf_rayleigh(x, sigma, dtype=None):
     """Computes Rayleigh PDF
 
     Parameters
@@ -599,16 +711,20 @@ def tf_rayleigh(x, sigma):
         The input tensor.
     sigma : tf.Tensor
         The sigma parameter of the Rayleigh distribution.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The PDF of the Rayleigh distribution evaluated at x.
     """
+    x, sigma = tf_cast(dtype, x, sigma)
     return x / (sigma**2) * tf.exp(-0.5 * (x / sigma) ** 2)
 
 
-def rayleigh(x, sigma):
+def rayleigh(x, sigma, dtype=None):
     """Computes Rayleigh PDF
 
     Parameters
@@ -617,16 +733,20 @@ def rayleigh(x, sigma):
         The input tensor.
     sigma : array_like
         The sigma parameter of the Rayleigh distribution.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The PDF of the Rayleigh distribution evaluated at x.
     """
+    x, sigma = cast(dtype, x, sigma)
     return x / (sigma**2) * np.exp(-0.5 * (x / sigma) ** 2)
 
 
-def tf_rayleigh_cdf(x, sigma):
+def tf_rayleigh_cdf(x, sigma, dtype=None):
     """Computes CDF of Rayleigh distribution.
 
     Parameters
@@ -635,16 +755,20 @@ def tf_rayleigh_cdf(x, sigma):
         The input tensor.
     sigma : tf.Tensor
         The sigma parameter of the Rayleigh distribution.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     tf.Tensor
         The CDF of the Rayleigh distribution evaluated at x.
     """
+    x, sigma = tf_cast(dtype, x, sigma)
     return 1 - tf.exp(-0.5 * (x / sigma) ** 2)
 
 
-def rayleigh_cdf(x, sigma):
+def rayleigh_cdf(x, sigma, dtype=None):
     """Computes CDF of Rayleigh distribution.
 
     Parameters
@@ -653,16 +777,20 @@ def rayleigh_cdf(x, sigma):
         The input tensor.
     sigma : array_like
         The sigma parameter of the Rayleigh distribution.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The CDF of the Rayleigh distribution evaluated at x.
     """
+    x, sigma = cast(dtype, x, sigma)
     return 1 - np.exp(-0.5 * (x / sigma) ** 2)
 
 
-def von_mises_pdf(x, sigma, kent_min=np.deg2rad(7)):
+def von_mises_pdf(x, sigma, kent_min=np.deg2rad(7), dtype=None):
     """Computes the von Mises-Fisher PDF on the sphere
 
     The PDF is defined and normalized in cartesian
@@ -679,12 +807,16 @@ def von_mises_pdf(x, sigma, kent_min=np.deg2rad(7)):
         The value over which to use the von Mises-Fisher distribution.
         Underneath, a 2D Gaussian approximation is used for more numerical
         stability.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The PDF evaluated at the provided opening angles x.
     """
+    x, sigma = cast(dtype, x, sigma)
     x = np.atleast_1d(x)
     sigma = np.atleast_1d(sigma)
 
@@ -708,7 +840,7 @@ def von_mises_pdf(x, sigma, kent_min=np.deg2rad(7)):
     return result
 
 
-def von_mises_in_dPsi_pdf(x, sigma, kent_min=np.deg2rad(7)):
+def von_mises_in_dPsi_pdf(x, sigma, kent_min=np.deg2rad(7), dtype=None):
     """Computes the von Mises-Fisher PDF on the sphere
 
     The PDF is defined and normalized in the opening angle dPsi.
@@ -723,12 +855,17 @@ def von_mises_in_dPsi_pdf(x, sigma, kent_min=np.deg2rad(7)):
         The value over which to use the von Mises-Fisher distribution.
         Underneath, a 2D Gaussian approximation is used for more numerical
         stability.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
     array_like
         The PDF evaluated at the provided opening angles x.
     """
+    x, sigma = cast(dtype, x, sigma)
+
     # switching coordinates from (dx1, dx2) to spherical
     # coordinates (dPsi, phi) means that we have to include
     # the jakobi determinant sin dPsi
@@ -741,7 +878,7 @@ def von_mises_in_dPsi_pdf(x, sigma, kent_min=np.deg2rad(7)):
     )
 
 
-def von_mises_in_dPsi_cdf(x, sigma, kent_min=np.deg2rad(7)):
+def von_mises_in_dPsi_cdf(x, sigma, kent_min=np.deg2rad(7), dtype=None):
     """Computes the von Mises-Fisher CDF on the sphere
 
     The underlying PDF is defined and normalized in the opening angle dPsi.
@@ -758,6 +895,9 @@ def von_mises_in_dPsi_cdf(x, sigma, kent_min=np.deg2rad(7)):
         The value over which to use the von Mises-Fisher distribution.
         Underneath, a 2D Gaussian approximation is used for more numerical
         stability.
+    dtype : str, optional
+        The data type of the output tensor, by default None.
+        If provided, the inputs are cast to this data type.
 
     Returns
     -------
@@ -765,6 +905,7 @@ def von_mises_in_dPsi_cdf(x, sigma, kent_min=np.deg2rad(7)):
         The CDF evaluated at the provided opening angles x.
     """
     assert len(x) == len(sigma), ("Unequal lengths:", len(x), len(sigma))
+    x, sigma = cast(dtype, x, sigma)
     x = np.atleast_1d(x)
     sigma = np.atleast_1d(sigma)
     result = []

--- a/egenerator/utils/build_components.py
+++ b/egenerator/utils/build_components.py
@@ -114,15 +114,23 @@ def build_loss_module(loss_module_settings):
     # A list of dictionaries is provided which each define a loss module
     else:
         loss_modules = []
+        loss_modules_weights = []
         for settings in loss_module_settings:
             LossModuleClass = misc.load_class(settings["loss_module"])
+            if "loss_module_weight" in settings:
+                loss_modules_weights.append(settings["loss_module_weight"])
+            else:
+                loss_modules_weights.append(1.0)
             loss_module_i = LossModuleClass()
             loss_module_i.configure(config=settings["config"])
             loss_modules.append(loss_module_i)
 
         # create a multi loss module from a list of given loss modules
         loss_module = MultiLossModule()
-        loss_module.configure(loss_modules=loss_modules)
+        loss_module.configure(
+            loss_modules=loss_modules,
+            loss_modules_weights=loss_modules_weights,
+        )
 
     return loss_module
 

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -49,15 +49,6 @@ def safe_cdf_clip(cdf_values, tol=1e-5):
     return cdf_values
 
 
-@tf.function(
-    input_signature=[
-        tf.TensorSpec(shape=(None, 2), dtype=tf.float32),
-        tf.TensorSpec(shape=(None, 3), dtype=tf.int32),
-        tf.TensorSpec(shape=(None, 2), dtype=tf.float32),
-        tf.TensorSpec(shape=(None, 3), dtype=tf.int32),
-        tf.TensorSpec(shape=(None, 1), dtype=tf.float32),
-    ]
-)
 def get_pulse_cdf_exclusion(
     x_pulses,
     x_pulses_ids,

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 
 
-def safe_cdf_clip(cdf_values, tol=1e-4):
+def safe_cdf_clip(cdf_values, tol=1e-5):
     """Perform clipping of CDF values
 
     Clips provided CDF values to be between 0 and 1.
@@ -13,7 +13,7 @@ def safe_cdf_clip(cdf_values, tol=1e-4):
     cdf_values : tf.Tensor
         The CDF values to clip.
     tol : float, optional
-        The tolerance for clipping, by default 1e-2.
+        The tolerance for clipping, by default 1e-5.
 
     Returns
     -------

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -1,0 +1,47 @@
+import tensorflow as tf
+
+
+def safe_cdf_clip(cdf_values):
+    """Perform clipping of CDF values
+
+    Clips provided CDF values to be between 0 and 1.
+    Performs some debugging safety checks to make sure
+    to not clip too much.
+
+    Parameters
+    ----------
+    cdf_values : tf.Tensor
+        The CDF values to clip.
+
+    Returns
+    -------
+    tf.Tensor
+        The clipped CDF values.
+    """
+    # some safety checks to make sure we aren't clipping too much
+    asserts = []
+    asserts.append(
+        tf.debugging.Assert(
+            tf.reduce_all(
+                tf.math.logical_or(
+                    cdf_values > -1e-4,
+                    ~tf.math.is_finite(cdf_values),
+                )
+            ),
+            ["CDF values < 0!", tf.reduce_min(cdf_values)],
+        )
+    )
+    asserts.append(
+        tf.debugging.Assert(
+            tf.reduce_all(
+                tf.math.logical_or(
+                    cdf_values < 1.0001,
+                    ~tf.math.is_finite(cdf_values),
+                )
+            ),
+            ["CDF values > 1!", tf.reduce_max(cdf_values)],
+        )
+    )
+    with tf.control_dependencies(asserts):
+        cdf_values = tf.clip_by_value(cdf_values, 0.0, 1.0)
+    return cdf_values

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 
 
-def safe_cdf_clip(cdf_values):
+def safe_cdf_clip(cdf_values, tol=1e-3):
     """Perform clipping of CDF values
 
     Clips provided CDF values to be between 0 and 1.
@@ -12,6 +12,8 @@ def safe_cdf_clip(cdf_values):
     ----------
     cdf_values : tf.Tensor
         The CDF values to clip.
+    tol : float, optional
+        The tolerance for clipping, by default 1e-3.
 
     Returns
     -------
@@ -24,7 +26,7 @@ def safe_cdf_clip(cdf_values):
         tf.debugging.Assert(
             tf.reduce_all(
                 tf.math.logical_or(
-                    cdf_values > -1e-4,
+                    cdf_values > -tol,
                     ~tf.math.is_finite(cdf_values),
                 )
             ),
@@ -35,7 +37,7 @@ def safe_cdf_clip(cdf_values):
         tf.debugging.Assert(
             tf.reduce_all(
                 tf.math.logical_or(
-                    cdf_values < 1.0001,
+                    cdf_values < 1.0 + tol,
                     ~tf.math.is_finite(cdf_values),
                 )
             ),

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 
 
-def safe_cdf_clip(cdf_values, tol=1e-3):
+def safe_cdf_clip(cdf_values, tol=1e-2):
     """Perform clipping of CDF values
 
     Clips provided CDF values to be between 0 and 1.
@@ -13,7 +13,7 @@ def safe_cdf_clip(cdf_values, tol=1e-3):
     cdf_values : tf.Tensor
         The CDF values to clip.
     tol : float, optional
-        The tolerance for clipping, by default 1e-3.
+        The tolerance for clipping, by default 1e-2.
 
     Returns
     -------

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -47,3 +47,103 @@ def safe_cdf_clip(cdf_values, tol=1e-5):
     with tf.control_dependencies(asserts):
         cdf_values = tf.clip_by_value(cdf_values, 0.0, 1.0)
     return cdf_values
+
+
+@tf.function(
+    input_signature=[
+        tf.TensorSpec(shape=(None, 2), dtype=tf.float32),
+        tf.TensorSpec(shape=(None, 3), dtype=tf.int32),
+        tf.TensorSpec(shape=(None, 2), dtype=tf.float32),
+        tf.TensorSpec(shape=(None, 3), dtype=tf.int32),
+        tf.TensorSpec(shape=(None, 1), dtype=tf.float32),
+    ]
+)
+def get_pulse_cdf_exclusion(
+    x_pulses,
+    x_pulses_ids,
+    x_time_exclusions,
+    x_time_exclusions_ids,
+    tw_cdf_exclusion_reduced,
+):
+    """Get CDF exclusion for each pulse
+
+    Parameters
+    ----------
+    x_pulses : tf.Tensor
+        The pulses.
+        Shape: [n_pulses, 2]
+    x_pulses_ids : tf.Tensor
+        The pulse ids.
+        Shape: [n_pulses, 3]
+    x_time_exclusions : tf.Tensor
+        The time exclusions.
+        Shape: [n_tw, 2]
+    x_time_exclusions_ids : tf.Tensor
+        The time exclusion ids.
+        Shape: [n_tw, 3]
+    tw_cdf_exclusion_reduced : tf.Tensor
+        The (reduced) CDF exclusion for the entire model.
+        Shape: [n_tw, 1]
+
+    Returns
+    -------
+    tf.Tensor
+        The CDF exclusion for each pulse.
+        Shape: [n_pulses]
+    """
+
+    def get_pulse_cdf_exclusion_per_tw(elem_i):
+        """Get pulse cdf exclusion per time window
+
+        Parameters
+        ----------
+        elem_i : tuple
+            Tuple of x_time_exclusions_ids, x_time_exclusions, tw_cdf_exclusion_reduced
+        """
+        (
+            x_time_exclusions_ids_i,
+            x_time_exclusions_i,
+            tw_cdf_exclusion_reduced_i,
+        ) = elem_i
+
+        mask = tf.reduce_all(x_pulses_ids == x_time_exclusions_ids_i, axis=1)
+        mask &= x_pulses[:, 1] > x_time_exclusions_i[0]
+        return tf.where(
+            mask,
+            tw_cdf_exclusion_reduced_i,
+            tf.zeros_like(tw_cdf_exclusion_reduced_i),
+        )
+
+    # -------------------------
+    # Implementation via map_fn
+    # -------------------------
+    # pulse_cdf_exclusion = tf.map_fn(
+    #     get_pulse_cdf_exclusion_per_tw,
+    #     elems=(x_time_exclusions_ids, x_time_exclusions, tw_cdf_exclusion_reduced),
+    #     fn_output_signature=tf.TensorSpec(shape=x_pulses.shape[0], dtype=x_pulses.dtype),
+    # )
+    # pulse_cdf_exclusion = tf.reduce_sum(pulse_cdf_exclusion, axis=0)
+
+    # ---------------------------------
+    # Implementation via vectorized_map
+    # ---------------------------------
+    # This implementation is faster than map_fn, but may require more memory
+    pulse_cdf_exclusion = tf.vectorized_map(
+        get_pulse_cdf_exclusion_per_tw,
+        (x_time_exclusions_ids, x_time_exclusions, tw_cdf_exclusion_reduced),
+    )
+    pulse_cdf_exclusion = tf.reduce_sum(pulse_cdf_exclusion, axis=0)
+
+    # -------------------------------------------------
+    # Implementation via unstack (requires known shape)
+    # -------------------------------------------------
+    # pulse_cdf_exclusion = tf.zeros_like(x_pulses[:, 0])
+    # for i, tw_exclusion_id in enumerate(tf.unstack(x_time_exclusions_ids, axis=0)):
+    #     mask = tf.reduce_all(x_pulses_ids == tw_exclusion_id, axis=1)
+    #     mask &= x_pulses[:, 1] > x_time_exclusions[i, 0]
+    #     pulse_cdf_exclusion = tf.where(
+    #         mask, pulse_cdf_exclusion + tw_cdf_exclusion_reduced[i], pulse_cdf_exclusion
+    #     )
+    # -------------------------------------------------
+
+    return pulse_cdf_exclusion

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -1,6 +1,54 @@
 import tensorflow as tf
 
 
+def clip_logits(logits, eps=None):
+    """Clip logits to avoid numerical instabilities
+
+    Parameters
+    ----------
+    logits : tf.Tensor
+        The logits to clip.
+    eps : float, optional
+        The epsilon value to clip to, by default None.
+        If None the value will be clipped to 1e-37 for float32
+        and 1e-307 for float64.
+
+    Returns
+    -------
+    tf.Tensor
+        The clipped logits.
+    """
+    if eps is None:
+        # Up to these values, the log returns finite values
+        if logits.dtype == tf.float32:
+            eps = 1e-37
+        elif logits.dtype == tf.float64:
+            eps = 1e-307
+        else:
+            raise ValueError(f"Unknown dtype for logits: {logits.dtype}")
+    return tf.clip_by_value(logits, eps, float("inf"))
+
+
+def safe_log(logits, eps=None):
+    """Safe log operation
+
+    Parameters
+    ----------
+    logits : tf.Tensor
+        The logits to log.
+    eps : float, optional
+        The epsilon value to clip to, by default None.
+        If None the value will be clipped to 1e-37 for float32
+        and 1e-307 for float64.
+
+    Returns
+    -------
+    tf.Tensor
+        The safe log of the logits.
+    """
+    return tf.math.log(clip_logits(logits, eps=eps))
+
+
 def safe_cdf_clip(cdf_values, tol=1e-5):
     """Perform clipping of CDF values
 

--- a/egenerator/utils/tf_helpers.py
+++ b/egenerator/utils/tf_helpers.py
@@ -1,7 +1,7 @@
 import tensorflow as tf
 
 
-def safe_cdf_clip(cdf_values, tol=1e-2):
+def safe_cdf_clip(cdf_values, tol=1e-4):
     """Perform clipping of CDF values
 
     Clips provided CDF values to be between 0 and 1.

--- a/test/data/modules/data/test_pulse_data.py
+++ b/test/data/modules/data/test_pulse_data.py
@@ -300,7 +300,7 @@ class TestPulseDataModule(unittest.TestCase):
                         ),
                         DataTensor(
                             name="x_pulses_ids",
-                            shape=[None, 3],
+                            shape=[None, 4],
                             tensor_type="data",
                             vector_info={
                                 "type": "index",
@@ -522,7 +522,7 @@ class TestPulseDataModule(unittest.TestCase):
         pulses : array_like
             The pulses. Shape: [n_pulses, 3]
         pulses_ids : array_like
-            The pulses ids. Shape: [n_pulses, 3]
+            The pulses ids. Shape: [n_pulses, 4]
         event : int
             The (zero-based) event id.
         string : int

--- a/test/model/multi_source/test_independent.py
+++ b/test/model/multi_source/test_independent.py
@@ -76,7 +76,10 @@ class TestIndependentMultiSource(unittest.TestCase):
             "cascade_00002_energy",
             "cascade_00002_time",
         ]
-        self.config_cascade = {"cascade_setting": 1337}
+        self.config_cascade = {
+            "cascade_setting": 1337,
+            "float_precision": "float32",
+        }
         self.base_sources = {
             "cascade": self.get_cascade_source(
                 config=self.config_cascade, data_trafo=self.data_trafo

--- a/test/model/multi_source/test_independent.py
+++ b/test/model/multi_source/test_independent.py
@@ -38,7 +38,7 @@ class DummyDataTrafo(BaseComponent):
                     ),
                     DataTensor(
                         name="x_pulses_ids",
-                        shape=[7, 3],
+                        shape=[7, 4],
                         tensor_type="data",
                         dtype="int32",
                     ),
@@ -514,7 +514,7 @@ class TestIndependentMultiSource(unittest.TestCase):
         data_batch_dict = {
             "x_parameters": tf.ones([1, source.num_parameters]),
             "x_pulses": tf.ones([7, 2]),
-            "x_pulses_ids": tf.zeros([7, 3], dtype=tf.int32),
+            "x_pulses_ids": tf.zeros([7, 4], dtype=tf.int32),
         }
         result_tensors = self.source.get_tensors(data_batch_dict, True)
         self.assertTrue(result_tensors["dom_charges"].shape == [1, 86, 60, 1])

--- a/test/test_model_prediction.py
+++ b/test/test_model_prediction.py
@@ -77,7 +77,7 @@ class TestModelPrediction(unittest.TestCase):
             self.x_time_exclusions_ids.append([0, s - 1, d - 1])
 
             for i in range(n_pulses):
-                self.x_pulses_ids.append([0, s - 1, d - 1])
+                self.x_pulses_ids.append([0, s - 1, d - 1, i])
         self.x_time_window = np.array([[self.t_min, self.t_max]])
 
         # ----------


### PR DESCRIPTION
Adds MPE likelihood to event-generator. To use the likelihood, a model must also evaluate the CDF for the provided pulse times. The MultiSource object will properly combine CDF values if they are provided.

Other changes include:

- Streamline definition and usage of model's epsilon value
- Allow precision set individually for loss functions and a model's PDF/CDF calulation